### PR TITLE
Ignore missing directories when parsing projects

### DIFF
--- a/ada/extensions/analysis/c_api/unit_providers/body
+++ b/ada/extensions/analysis/c_api/unit_providers/body
@@ -58,7 +58,8 @@
       end if;
 
       begin
-         Load (Project.all, Create (+PF), Env);
+         Load (Project.all, Create (+PF), Env,
+               Report_Missing_Dirs => False);
       exception
          when Invalid_Project =>
             Free (Env);


### PR DESCRIPTION
Those include the object directories, which libadalang does not use.