### PR TITLE
Restrict build parallelism for Travis CI

### DIFF
--- a/utils/travis-script.sh
+++ b/utils/travis-script.sh
@@ -5,5 +5,5 @@ set -e
 
 export PATH=$GNAT_PATH/bin:$PATH
 gprbuild --version
-ada/manage.py make
+ada/manage.py make -j16
 ada/manage.py test


### PR DESCRIPTION
This will hopefully avoid out of memory errors when building the
generated quex_lexer.c unit.