### PR TITLE
Make SubpRenamingDecl and NullSubpDecl resolve their corresponding decl

### DIFF
--- a/ada/language/ast.py
+++ b/ada/language/ast.py
@@ -4335,31 +4335,8 @@ class SubpDecl(ClassicSubpDecl):
     aspects = Field(type=T.AspectSpec)
 
 
-class NullSubpDecl(ClassicSubpDecl):
-    aspects = Field(type=T.AspectSpec)
-
-
 class AbstractSubpDecl(ClassicSubpDecl):
     aspects = Field(type=T.AspectSpec)
-
-
-class SubpRenamingDecl(ClassicSubpDecl):
-    renames = Field(type=T.RenamingClause)
-    aspects = Field(type=T.AspectSpec)
-
-    xref_entry_point = Property(True)
-    xref_equation = Property(Or(
-        And(
-            Entity.renames.renamed_object.xref_no_overloading(all_els=True),
-            Predicate(BasicDecl.subp_decl_match_signature,
-                      Entity.renames.renamed_object.ref_var,
-                      Entity.cast(T.BasicDecl))
-        ),
-        # Operators might be built-in, so if we cannot find a reference, we'll
-        # just abandon resolution...
-        If(Entity.renames.renamed_object.is_operator_name,
-           LogicTrue(), LogicFalse())
-    ))
 
 
 class Pragma(AdaNode):
@@ -8651,6 +8628,29 @@ class ExprFunction(BaseSubpBody):
     )
 
     xref_entry_point = Property(True)
+
+
+class NullSubpDecl(BaseSubpBody):
+    aspects = Field(type=T.AspectSpec)
+
+
+class SubpRenamingDecl(BaseSubpBody):
+    renames = Field(type=T.RenamingClause)
+    aspects = Field(type=T.AspectSpec)
+
+    xref_entry_point = Property(True)
+    xref_equation = Property(Or(
+        And(
+            Entity.renames.renamed_object.xref_no_overloading(all_els=True),
+            Predicate(BasicDecl.subp_decl_match_signature,
+                      Entity.renames.renamed_object.ref_var,
+                      Entity.cast(T.BasicDecl))
+        ),
+        # Operators might be built-in, so if we cannot find a reference, we'll
+        # just abandon resolution...
+        If(Entity.renames.renamed_object.is_operator_name,
+           LogicTrue(), LogicFalse())
+    ))
 
 
 class SubpBody(BaseSubpBody):

--- a/ada/testsuite/tests/ada_api/foreign_nodes/test.out
+++ b/ada/testsuite/tests/ada_api/foreign_nodes/test.out
@@ -42,6 +42,7 @@ $root = LexEnv(Primary, Parent=null):
     p1: [<NullSubpDecl ["P1"] 2:4-2:25>]
 
 @3 = LexEnv(Primary, Parent=@2, Node=<NullSubpDecl ["P1"] 2:4-2:25>):
+  Referenced: <NullSubpDecl ["P1"] 2:4-2:25>: LexEnv(Primary, Node=<CompilationUnit 1:1-3:9>)
     <empty>
 
 ## Child ##
@@ -123,6 +124,7 @@ $root = LexEnv(Primary, Parent=null):
     standard: [<PackageDecl ["Standard"] 1:1-121:14>]
 
 @4 = LexEnv(Primary, Parent=@3, Node=<NullSubpDecl ["P2"] 2:4-2:25>):
+  Referenced: <NullSubpDecl ["P2"] 2:4-2:25>: LexEnv(Primary, Node=<CompilationUnit 1:1-3:15>)
     <empty>
 
 =====================
@@ -169,6 +171,7 @@ $root = LexEnv(Primary, Parent=null):
     p1: [<NullSubpDecl ["P1"] 2:4-2:25>]
 
 @3 = LexEnv(Primary, Parent=@2, Node=<NullSubpDecl ["P1"] 2:4-2:25>):
+  Referenced: <NullSubpDecl ["P1"] 2:4-2:25>: LexEnv(Primary, Node=<CompilationUnit 1:1-3:9>)
     <empty>
 
 ## Child ##
@@ -250,6 +253,7 @@ $root = LexEnv(Primary, Parent=null):
     standard: [<PackageDecl ["Standard"] 1:1-121:14>]
 
 @4 = LexEnv(Primary, Parent=@3, Node=<NullSubpDecl ["P2"] 2:4-2:25>):
+  Referenced: <NullSubpDecl ["P2"] 2:4-2:25>: LexEnv(Primary, Node=<CompilationUnit 1:1-3:15>)
     <empty>
 
 Done.


### PR DESCRIPTION
This is done by making them subclasses of `BaseSubpBody` instead of `ClassicSubpDecl`.
This makes them work the same as `ExprFunction`.

This makes conceptual sense, since they work the same way as a normal `SubpBody`: they can declare a subprogram or complete a previous declaration.

Fixes #195.