### PR TITLE
S215-003: Fix bug in BasicDecl.unique_iname

### DIFF
--- a/ada/language/ast.py
+++ b/ada/language/ast.py
@@ -228,11 +228,11 @@ class AdaNode(ASTNode):
     )
 
     @langkit_property(return_type=T.String)
-    def uit():
+    def custom_id_text():
         """
-        Unique identifying text used to recognize this node. Not applicable to
-        all nodes, but on AdaNode because it spans more than one hierarchy of
-        node types.
+        Custom Unique identifying text used to recognize this node. Not
+        applicable to all nodes, but on AdaNode because it spans more than one
+        hierarchy of node types.
         """
         return String("")
 
@@ -1546,24 +1546,26 @@ class BasicDecl(AdaNode):
         subprograms, this will include the profile.
         """
         return Entity.match(
-            lambda _=T.AnonymousTypeDecl: Entity.uit,
-            lambda _: Entity.fully_qualified_name.concat(Entity.uit)
+            lambda _=T.AnonymousTypeDecl: Entity.custom_id_text,
+            lambda _: Entity.fully_qualified_name.concat(Entity.custom_id_text)
         )
 
     @langkit_property(return_type=T.String)
-    def uit():
+    def custom_id_text():
         return Entity.subp_spec_or_null.then(
             # For subprograms, we'll compute their profiles as the unique
             # identifying text.
             lambda ss: ss.unpacked_formal_params.then(
                 lambda ufp: String(" (").concat(
                     Entity.string_join(
-                        ufp.map(lambda p: p.spec.type_expression.uit),
+                        ufp.map(
+                            lambda p: p.spec.type_expression.custom_id_text
+                        ),
                         String(", ")
                     )
                 ).concat(String(")"))
             ).concat(ss.returns.then(
-                lambda r: String(" return ").concat(r.uit)
+                lambda r: String(" return ").concat(r.custom_id_text)
             )),
             default_val=String("")
         )
@@ -4363,9 +4365,9 @@ class EnumLitSynthTypeExpr(TypeExpr):
         Entity.parent.cast(T.EnumLiteralDecl).enum_type
     )
 
-    uit = Property(
-        # The UIT is the combination of the enum type name and of the enum
-        # literal name.
+    custom_id_text = Property(
+        # The custom_id_text is the combination of the enum type name and of
+        # the enum literal name.
         origin.bind(
             Self,
             Entity.designated_type.fully_qualified_name
@@ -4395,7 +4397,7 @@ class AnonymousType(TypeExpr):
     # Ideally we would compute a properly formatted version of the anonymous
     # type declaration. Using unparsing in order to avoid duplicating logic
     # between parsing/unparsing.
-    uit = Property(Entity.type_decl.text)
+    custom_id_text = Property(Entity.type_decl.text)
 
 
 class SubtypeIndication(TypeExpr):
@@ -4438,7 +4440,7 @@ class SubtypeIndication(TypeExpr):
             default_val=Entity.designated_type.is_static_decl
         ))
 
-    uit = Property(origin.bind(
+    custom_id_text = Property(origin.bind(
         Self,
         Entity.designated_type.fully_qualified_name
     ))

--- a/ada/testsuite/tests/python/unique_identifying_name/test.adb
+++ b/ada/testsuite/tests/python/unique_identifying_name/test.adb
@@ -1,0 +1,18 @@
+procedure A is
+   function Bar (X, Y : Integer) return Boolean is
+   begin
+      return X > Y;
+   end Bar;
+   function Bar (X : Integer) return Boolean is
+   begin
+      return X > 42;
+   end Bar;
+   procedure Bar (X : Integer) is
+   begin
+      null;
+   end Bar;
+   B : Boolean;
+begin
+   B := Bar (1, 2);
+   Bar (1);
+end A;

--- a/ada/testsuite/tests/python/unique_identifying_name/test.ads
+++ b/ada/testsuite/tests/python/unique_identifying_name/test.ads
@@ -1,0 +1,8 @@
+package Test is
+
+   function Foo (A : Integer; B : Integer; C : Integer) return Positive;
+   function Foo (A : Integer; B, C: Natural) return Natural;
+
+   type A is (B, C, D);
+
+end Test;

--- a/ada/testsuite/tests/python/unique_identifying_name/test.out
+++ b/ada/testsuite/tests/python/unique_identifying_name/test.out
@@ -1,0 +1,9 @@
+<SubpBody ["A"] test.adb:1:1-18:7> uuid is a
+<SubpBody ["Bar"] test.adb:2:4-5:12> uuid is a.bar (standard.integer, standard.integer) return standard.boolean
+<SubpBody ["Bar"] test.adb:6:4-9:12> uuid is a.bar (standard.integer) return standard.boolean
+<SubpBody ["Bar"] test.adb:10:4-13:12> uuid is a.bar (standard.integer)
+<SubpDecl ["Foo"] test.ads:3:4-3:73> uuid is test.foo (standard.integer, standard.integer, standard.integer) return standard.positive
+<SubpDecl ["Foo"] test.ads:4:4-4:61> uuid is test.foo (standard.integer, standard.natural, standard.natural) return standard.natural
+<EnumLiteralDecl ["B"] test.ads:6:15-6:16> uuid is test.a.b return test.a.b
+<EnumLiteralDecl ["C"] test.ads:6:18-6:19> uuid is test.a.c return test.a.c
+<EnumLiteralDecl ["D"] test.ads:6:21-6:22> uuid is test.a.d return test.a.d

--- a/ada/testsuite/tests/python/unique_identifying_name/test.py
+++ b/ada/testsuite/tests/python/unique_identifying_name/test.py
@@ -1,0 +1,21 @@
+from __future__ import absolute_import, division, print_function
+
+"""
+Test that the p_unique_identifying_name property works as one would expect.
+"""
+
+import libadalang as lal
+
+c = lal.AnalysisContext('utf-8')
+
+for f in ["test.adb", "test.ads"]:
+    u = c.get_from_file(f)
+
+    for s in u.root.findall(
+        lambda n: n.is_a(lal.BasicDecl) and n.p_is_subprogram
+    ):
+        try:
+            print("{} uuid is {}".format(s, s.p_unique_identifying_name))
+        except lal.PropertyError:
+            print("Error on uuid for {}".format(s))
+            raise

--- a/ada/testsuite/tests/python/unique_identifying_name/test.yaml
+++ b/ada/testsuite/tests/python/unique_identifying_name/test.yaml
@@ -1,0 +1,2 @@
+driver: python
+input_sources: []


### PR DESCRIPTION
So far we only considered subprogram decls, not bodies, so
unique_identifying_name for subp bodies was not computed correctly.

Also the uit for EnumLitSynthTypeExpr was not computed correctly.

Add test for all different known cases.