### PR TITLE
Fix Travis CI on MacOS X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ env:
     - ADALIB_DIR=$HOME/adalib
     - TOOLS_DIR=$HOME/build_tools
     - INSTALL_DIR=$HOME/install
+    - LIBRARY_PATH=/usr/local/lib
 
 matrix:
   include:

--- a/utils/travis-install.sh
+++ b/utils/travis-install.sh
@@ -95,6 +95,8 @@ gcc -v
 # Build gnatcoll-bindings
 (
     cd $TOOLS_DIR/gnatcoll-bindings
+    #  Darwin has gmp installed at /usr/local/
+    export CPATH=/usr/local/include
     for component in iconv gmp
     do
         (


### PR DESCRIPTION
With GNAT Community 2019 gnatcoll-bindings is unable to fine gmp.h
in /usr/local/include, where GMP is installed on Travis. Set CPATH
fixes this.