### PR TITLE
S902-009: Fix next_part.

### DIFF
--- a/ada/language/ast.py
+++ b/ada/language/ast.py
@@ -3392,7 +3392,7 @@ class BaseTypeDecl(BasicDecl):
             # The next part of a (non-private) incomplete type declaration must
             # either be in the same declarative scope...
             itd.node_env
-            .get(itd.name.name_symbol, LK.flat, categories=noprims)
+            .get(itd.name.name_symbol, LK.minimal, categories=noprims)
             .find(lambda t: t.is_a(BaseTypeDecl) & (t != Entity))
 
             # Or in the particular case of taft-amendment types where the
@@ -3403,7 +3403,7 @@ class BaseTypeDecl(BasicDecl):
                 Entity.declarative_scope.parent
                 .cast_or_raise(T.BasePackageDecl).as_entity.body_part.then(
                     lambda p: p.children_env
-                    .get(itd.name.name_symbol, LK.flat, categories=noprims)
+                    .get(itd.name.name_symbol, LK.minimal, categories=noprims)
                     .find(lambda t: t.is_a(BaseTypeDecl))
                 )
             )).cast(BaseTypeDecl),

--- a/ada/testsuite/tests/name_resolution/S902-009/root-p.adb
+++ b/ada/testsuite/tests/name_resolution/S902-009/root-p.adb
@@ -1,0 +1,7 @@
+package body Root.P is
+   function F (X : access T) is
+   begin
+      null;
+   end F;
+end Root.P;
+

--- a/ada/testsuite/tests/name_resolution/S902-009/root-p.ads
+++ b/ada/testsuite/tests/name_resolution/S902-009/root-p.ads
@@ -1,0 +1,9 @@
+package Root.P is
+private
+   type T;
+
+   procedure F (X : access T);
+
+   type T is null record;
+end Root.P;
+

--- a/ada/testsuite/tests/name_resolution/S902-009/root.ads
+++ b/ada/testsuite/tests/name_resolution/S902-009/root.ads
@@ -1,0 +1,5 @@
+limited with Root.P;
+
+package Root is
+
+end Root;

--- a/ada/testsuite/tests/name_resolution/S902-009/test.adb
+++ b/ada/testsuite/tests/name_resolution/S902-009/test.adb
@@ -1,0 +1,19 @@
+procedure Main is
+   package P is
+   private
+      type T;
+
+      procedure F (X : access T);
+
+      type T is null record;
+   end P;
+
+   package body P is
+      function F (X : access T) is
+      begin
+         null;
+      end F;
+   end P;
+begin
+   null;
+end Main;

--- a/ada/testsuite/tests/name_resolution/S902-009/test.out
+++ b/ada/testsuite/tests/name_resolution/S902-009/test.out
@@ -1,0 +1,4 @@
+Analyzing root.ads
+##################
+
+Done.

--- a/ada/testsuite/tests/name_resolution/S902-009/test.yaml
+++ b/ada/testsuite/tests/name_resolution/S902-009/test.yaml
@@ -1,0 +1,2 @@
+driver: name-resolution
+input_sources: [root.ads]


### PR DESCRIPTION
Minimal lookups are sufficient here because the next part should be
in the same environment. This also prevents finding back the original
node when doing an env lookup on the package's body (since a package
declaration is the parent of its body).

An alternative could have been to filter out the results that are
equivalent to Entity, but it seems cleaner that way.