### PR TITLE
R219-008: Fix erroneous refactoring.

### DIFF
--- a/ada/language/ast.py
+++ b/ada/language/ast.py
@@ -1766,8 +1766,11 @@ class BasicDecl(AdaNode):
         reused by subclasses when they override next_part_for_decl.
         """
         ignore(Var(
-            Self.enclosing_compilation_unit.decl.as_bare_entity
-            ._.defining_name._.referenced_unit(UnitBody)
+            Self.enclosing_compilation_unit.decl.match(
+                lambda _=Body: No(AnalysisUnit),
+                lambda b=BasicDecl:
+                b.as_bare_entity._.defining_name._.referenced_unit(UnitBody)
+            )
         ))
 
         return If(


### PR DESCRIPTION
While removing the p_unit_body property as part of the
"multiple units per file" patch, I made an error while copying its
logic in the p_basic_decl_next_part_for_decl property by discarding
the case where the enclosing compilation unit is a Body, in which
the "body unit" is simply itself.

This was causing a weird error in the ALS because it ended up fetching
the "body unit" in another file.