### PR TITLE
SC18-041 Eval_Range_Attr use P_Designated_Type_Decl for Subtype_Decl

### DIFF
--- a/ada/extensions/src/libadalang-expr_eval.adb
+++ b/ada/extensions/src/libadalang-expr_eval.adb
@@ -215,19 +215,21 @@ package body Libadalang.Expr_Eval is
                  (D.As_Type_Decl.F_Type_Def.As_Ada_Node, A);
             when Ada_Subtype_Decl =>
                declare
+                  Subtype_Indication : constant LAL.Subtype_Indication :=
+                     D.As_Subtype_Decl.F_Subtype;
                   Constraint : constant LAL.Range_Constraint :=
-                     D.As_Subtype_Decl.F_Subtype.F_Constraint
-                     .As_Range_Constraint;
+                     Subtype_Indication.F_Constraint.As_Range_Constraint;
                begin
                   --  If subtype decl with a range constraint, eval the range
-                  --  constraint. Else, eval the attribute on the canonical
-                  --  type.
+                  --  constraint. Else, eval the attribute on the designated
+                  --  subtype.
                   if not Constraint.Is_Null then
                      return Eval_Range_Attr
                        (Constraint.F_Range.F_Range.As_Ada_Node, A);
                   else
                      return Eval_Range_Attr
-                       (D.As_Subtype_Decl.P_Canonical_Type.As_Ada_Node, A);
+                       (Subtype_Indication.P_Designated_Type_Decl.As_Ada_Node,
+                        A);
                   end if;
                end;
             when Ada_Bin_Op_Range =>

--- a/ada/testsuite/tests/ada_api/static_expr_eval/test.adb
+++ b/ada/testsuite/tests/ada_api/static_expr_eval/test.adb
@@ -65,4 +65,22 @@ begin
    begin
       null;
    end;
+
+   --  Subtypes AttributeRef
+   declare
+      type A is range -100 .. 100;
+      subtype B is A range -10 .. 10;
+      subtype C is B;
+
+      A_First : A := A'First;
+      A_Last  : A := A'Last;
+
+      B_First : B := B'First;
+      B_Last  : B := B'Last;
+
+      C_First : C := C'First;
+      C_Last  : C := C'Last;
+   begin
+      null;
+   end;
 end Test;

--- a/ada/testsuite/tests/ada_api/static_expr_eval/test.out
+++ b/ada/testsuite/tests/ada_api/static_expr_eval/test.out
@@ -81,4 +81,22 @@ Expr <ObjectDecl ["Wide_Wide_A"] test.adb:63:7-63:53> evaluated to Int 97
 Expr <ObjectDecl ["Wide_Wide_Smiley"] test.adb:64:7-64:53> evaluated to Int 128512
    Int value is 128512
 
+Expr <ObjectDecl ["A_First"] test.adb:75:7-75:30> evaluated to Int -100
+   Int value is -100
+
+Expr <ObjectDecl ["A_Last"] test.adb:76:7-76:29> evaluated to Int 100
+   Int value is 100
+
+Expr <ObjectDecl ["B_First"] test.adb:78:7-78:30> evaluated to Int -10
+   Int value is -10
+
+Expr <ObjectDecl ["B_Last"] test.adb:79:7-79:29> evaluated to Int 10
+   Int value is 10
+
+Expr <ObjectDecl ["C_First"] test.adb:81:7-81:30> evaluated to Int -10
+   Int value is -10
+
+Expr <ObjectDecl ["C_Last"] test.adb:82:7-82:29> evaluated to Int 10
+   Int value is 10
+
 Done.


### PR DESCRIPTION
P_Canonical_Type was used instead. This is wrong if a hierarchy of
subtypes with multiple ranges is defined.