### PR TITLE
RA22-015: Fix token declaration order for the concrete syntax.

### DIFF
--- a/ada/language/lexer.py
+++ b/ada/language/lexer.py
@@ -278,8 +278,9 @@ rules += [
 
     # Literals
     (Pattern('{integer_literal}'),       Token.Integer),
-    (Pattern('{decimal_literal}'),       Token.Decimal),
     (Pattern('{based_integer_literal}'), Token.Integer),
+
+    (Pattern('{decimal_literal}'),       Token.Decimal),
     (Pattern('{based_decimal_literal}'), Token.Decimal),
 
     (Pattern('{p_string}'),         Token.String),


### PR DESCRIPTION
The concrete syntax for lexers allows defining multiple rules to produce a token
by using the `or(...)` construct. There is however a loss of expressivity because
there can't be any interleaving rule between the alternatives.

With this new restriction in place, libadalang's lexer could not be correctly
unparsed, because some tokens (Integer and Decimal) were produced by multiple
rules that were not consecutive, and therefore not translatable to an `or(...)`
construct.

This fix is simply to reorder them (which should not impact anything) so
as to allow a correct translation to the new concrete syntax.