### PR TITLE
.gitignore: add the lktl shortcut

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ lkadalog
 lkgdb
 lkex
 lksp
+lktl
 lktp
 .build_mode
 


### PR DESCRIPTION
I use `lktl` as a shortcut symlink to liblktlang’s spec.