### PR TITLE
T212-032: Never return Generic_*_Internal nodes from Parent_Basic_Decl.

### DIFF
--- a/ada/language/ast.py
+++ b/ada/language/ast.py
@@ -371,7 +371,7 @@ class AdaNode(ASTNode):
                                     from_rebound=False
                                 )
                             ),
-                            sp.cast(T.BasicDecl)
+                            sp.parent.cast(T.BasicDecl)
                         )
                     )
                 ),

--- a/ada/testsuite/tests/properties/is_visible/pkg.ads
+++ b/ada/testsuite/tests/properties/is_visible/pkg.ads
@@ -1,5 +1,10 @@
 package Pkg is
    Test_Pkg_Public : Integer;
+
+   generic
+   package G is
+      Test_Pkg_Generic_Child : Integer;
+   end G;
 private
    Test_Pkg_Private : Integer;
 

--- a/ada/testsuite/tests/properties/is_visible/pkg_g.ads
+++ b/ada/testsuite/tests/properties/is_visible/pkg_g.ads
@@ -1,0 +1,4 @@
+generic
+package Pkg_G is
+   Test_Generic_Pkg : Integer;
+end Pkg_G;

--- a/ada/testsuite/tests/properties/is_visible/test.out
+++ b/ada/testsuite/tests/properties/is_visible/test.out
@@ -6,6 +6,14 @@ Test_Pkg_Public           is visible to        Origin_Pkg_Child_Subp ? True
 Test_Pkg_Public           is visible to         Origin_Pkg_Child_Pkg ? True
 Test_Pkg_Public           is visible to    Origin_Pkg_Child_Pkg_Body ? True
 
+Test_Pkg_Generic_Child    is visible to                  Origin_Main ? True
+Test_Pkg_Generic_Child    is visible to              Origin_Pkg_Body ? True
+Test_Pkg_Generic_Child    is visible to        Origin_Pkg_Inner_Body ? True
+Test_Pkg_Generic_Child    is visible to       Origin_Other_Pkg_Inner ? True
+Test_Pkg_Generic_Child    is visible to        Origin_Pkg_Child_Subp ? True
+Test_Pkg_Generic_Child    is visible to         Origin_Pkg_Child_Pkg ? True
+Test_Pkg_Generic_Child    is visible to    Origin_Pkg_Child_Pkg_Body ? True
+
 Test_Pkg_Private          is visible to                  Origin_Main ? False
 Test_Pkg_Private          is visible to              Origin_Pkg_Body ? True
 Test_Pkg_Private          is visible to        Origin_Pkg_Inner_Body ? True
@@ -29,5 +37,13 @@ Test_Pkg_Inner_Private    is visible to       Origin_Other_Pkg_Inner ? False
 Test_Pkg_Inner_Private    is visible to        Origin_Pkg_Child_Subp ? False
 Test_Pkg_Inner_Private    is visible to         Origin_Pkg_Child_Pkg ? False
 Test_Pkg_Inner_Private    is visible to    Origin_Pkg_Child_Pkg_Body ? False
+
+Test_Generic_Pkg          is visible to                  Origin_Main ? True
+Test_Generic_Pkg          is visible to              Origin_Pkg_Body ? True
+Test_Generic_Pkg          is visible to        Origin_Pkg_Inner_Body ? True
+Test_Generic_Pkg          is visible to       Origin_Other_Pkg_Inner ? True
+Test_Generic_Pkg          is visible to        Origin_Pkg_Child_Subp ? True
+Test_Generic_Pkg          is visible to         Origin_Pkg_Child_Pkg ? True
+Test_Generic_Pkg          is visible to    Origin_Pkg_Child_Pkg_Body ? True
 
 Done

--- a/ada/testsuite/tests/properties/is_visible/test.yaml
+++ b/ada/testsuite/tests/properties/is_visible/test.yaml
@@ -1,5 +1,5 @@
 driver: python
 input_sources: [
-   main.adb, pkg.ads, pkg.adb, other_pkg.ads,
+   main.adb, pkg.ads, pkg.adb, other_pkg.ads, pkg_g.ads,
    pkg-child_subp.adb, pkg-child_pkg.ads, pkg-child_pkg.adb
 ]


### PR DESCRIPTION
In most cases, what we really want is the GenericPackageDecl, not the
GenericPackageInternal. Note that semantic_parent can still be used for that.