### PR TITLE
API work

### DIFF
--- a/ada/extensions/src/libadalang-expr_eval.adb
+++ b/ada/extensions/src/libadalang-expr_eval.adb
@@ -279,8 +279,9 @@ package body Libadalang.Expr_Eval is
          case D.Kind is
          when Ada_Name =>
             return Eval_Range_Attr
-              (D.As_Name
-               .P_Referenced_Decl_Internal (Try_Immediate => True)
+              (Decl
+                 (D.As_Name
+                  .P_Referenced_Decl_Internal (Try_Immediate => True))
                .As_Ada_Node,
                A);
 
@@ -381,7 +382,9 @@ package body Libadalang.Expr_Eval is
       case E.Kind is
          when Ada_Identifier | Ada_Dotted_Name =>
             return Eval_Decl
-              (E.As_Name.P_Referenced_Decl_Internal (Try_Immediate => True));
+              (Decl
+                 (E.As_Name.P_Referenced_Decl_Internal
+                      (Try_Immediate => True)).As_Basic_Decl);
 
          when Ada_Char_Literal =>
             declare
@@ -423,7 +426,9 @@ package body Libadalang.Expr_Eval is
                   --  If it's not a standard character type, evaluate it just
                   --  as any other enum literal.
                   return Eval_Decl
-                    (Char.P_Referenced_Decl_Internal (Try_Immediate => True));
+                    (Decl
+                      (Char.P_Referenced_Decl_Internal
+                        (Try_Immediate => True)).As_Basic_Decl);
                end if;
             end;
 

--- a/ada/language/ast.py
+++ b/ada/language/ast.py
@@ -2770,7 +2770,12 @@ class TypeDef(AdaNode):
 
     @langkit_property(dynamic_vars=[origin])
     def is_discrete_type():
-        return Entity.is_int_type | Entity.is_enum_type | Entity.is_char_type
+        return Entity.base_type.then(
+            lambda bt: bt.is_discrete_type,
+            default_val=Or(
+                Entity.is_int_type, Entity.is_enum_type, Entity.is_char_type
+            )
+        )
 
     @langkit_property(dynamic_vars=[origin])
     def is_int_type():

--- a/ada/language/ast.py
+++ b/ada/language/ast.py
@@ -8276,7 +8276,7 @@ class Name(Expr):
             No(BaseFormalParamHolder.entity)
         )
 
-    @langkit_property(public=True,
+    @langkit_property(public=True, return_type=T.BasicDecl.entity,
                       dynamic_vars=[default_imprecise_fallback()])
     def referenced_decl():
         """

--- a/ada/language/ast.py
+++ b/ada/language/ast.py
@@ -11204,7 +11204,7 @@ class AttributeRef(Name):
                             'Fore', 'Aft', 'Digits', 'Modulus',
                             'Address_Size', 'System_Allocator_Alignment',
                             'Finalization_Size', 'Descriptor_Size',
-                            'Alignment'),
+                            'Alignment', 'First_Bit', 'Last_Bit'),
             Entity.prefix.sub_equation
             & Self.universal_int_bind(Self.type_var),
 

--- a/ada/testsuite/ada/nameres.adb
+++ b/ada/testsuite/ada/nameres.adb
@@ -1189,13 +1189,13 @@ procedure Nameres is
             when Any =>
                for R of DN.P_Find_All_References (Units, Imprecise_Fallback)
                loop
-                  Print_Ref (R);
+                  Print_Ref (Ref (R));
                end loop;
 
             when Subp_Call =>
                for R of DN.P_Find_All_Calls (Units, Imprecise_Fallback)
                loop
-                  Print_Ref (R);
+                  Print_Ref (Ref (R));
                end loop;
 
             when Subp_Overriding =>

--- a/ada/testsuite/tests/name_resolution/derived_discrete/test.out
+++ b/ada/testsuite/tests/name_resolution/derived_discrete/test.out
@@ -1,0 +1,21 @@
+Analyzing test_derived_discrete.adb
+###################################
+
+Resolving xrefs for node <ObjectDecl ["C"] test_derived_discrete.adb:3:4-3:21>
+******************************************************************************
+
+Expr: <Id "B" test_derived_discrete.adb:3:8-3:9>
+  references: <DefiningName test_derived_discrete.adb:2:9-2:10>
+  type:       None
+Expr: <AttributeRef test_derived_discrete.adb:3:13-3:20>
+  references: None
+  type:       <TypeDecl ["B"] test_derived_discrete.adb:2:4-2:26>
+Expr: <Id "B" test_derived_discrete.adb:3:13-3:14>
+  references: <DefiningName test_derived_discrete.adb:2:9-2:10>
+  type:       None
+Expr: <Id "First" test_derived_discrete.adb:3:15-3:20>
+  references: None
+  type:       None
+
+
+Done.

--- a/ada/testsuite/tests/name_resolution/derived_discrete/test.yaml
+++ b/ada/testsuite/tests/name_resolution/derived_discrete/test.yaml
@@ -1,0 +1,2 @@
+driver: name-resolution
+input_sources: [test_derived_discrete.adb]

--- a/ada/testsuite/tests/name_resolution/derived_discrete/test_derived_discrete.adb
+++ b/ada/testsuite/tests/name_resolution/derived_discrete/test_derived_discrete.adb
@@ -1,0 +1,7 @@
+procedure Test_Derived_Discrete is
+   type B is new Integer;
+   C : B := B'First;
+   pragma Test_Statement;
+begin
+   null;
+end Test_Derived_Discrete;

--- a/ada/testsuite/tests/name_resolution/unint_attrs/test.out
+++ b/ada/testsuite/tests/name_resolution/unint_attrs/test.out
@@ -1,253 +1,297 @@
 Analyzing test_unint_attrs.adb
 ##############################
 
-Resolving xrefs for node <ObjectDecl ["A"] test_unint_attrs.adb:14:7-14:54>
+Resolving xrefs for node <ObjectDecl ["A"] test_unint_attrs.adb:14:7-14:55>
 ***************************************************************************
 
-Expr: <Id "Natural" test_unint_attrs.adb:14:20-14:27>
+Expr: <Id "Natural" test_unint_attrs.adb:14:21-14:28>
   references: <DefiningName __standard:5:11-5:18>
   type:       None
-Expr: <AttributeRef test_unint_attrs.adb:14:31-14:53>
+Expr: <AttributeRef test_unint_attrs.adb:14:32-14:54>
   references: None
   type:       <TypeDecl ["Universal_Int_Type_"] __standard:119:3-119:45>
-Expr: <Id "Float" test_unint_attrs.adb:14:31-14:36>
+Expr: <Id "Float" test_unint_attrs.adb:14:32-14:37>
   references: <DefiningName __standard:13:8-13:13>
   type:       <TypeDecl ["Float"] __standard:13:3-14:51>
-Expr: <Id "Machine_Mantissa" test_unint_attrs.adb:14:37-14:53>
+Expr: <Id "Machine_Mantissa" test_unint_attrs.adb:14:38-14:54>
   references: None
   type:       None
 
-Resolving xrefs for node <ObjectDecl ["B"] test_unint_attrs.adb:15:7-15:46>
+Resolving xrefs for node <ObjectDecl ["B"] test_unint_attrs.adb:15:7-15:47>
 ***************************************************************************
 
-Expr: <Id "Natural" test_unint_attrs.adb:15:20-15:27>
+Expr: <Id "Natural" test_unint_attrs.adb:15:21-15:28>
   references: <DefiningName __standard:5:11-5:18>
   type:       None
-Expr: <AttributeRef test_unint_attrs.adb:15:31-15:45>
+Expr: <AttributeRef test_unint_attrs.adb:15:32-15:46>
   references: None
   type:       <TypeDecl ["Universal_Int_Type_"] __standard:119:3-119:45>
-Expr: <Id "Float" test_unint_attrs.adb:15:31-15:36>
+Expr: <Id "Float" test_unint_attrs.adb:15:32-15:37>
   references: <DefiningName __standard:13:8-13:13>
   type:       <TypeDecl ["Float"] __standard:13:3-14:51>
-Expr: <Id "Mantissa" test_unint_attrs.adb:15:37-15:45>
+Expr: <Id "Mantissa" test_unint_attrs.adb:15:38-15:46>
   references: None
   type:       None
 
-Resolving xrefs for node <ObjectDecl ["C"] test_unint_attrs.adb:16:7-16:52>
+Resolving xrefs for node <ObjectDecl ["C"] test_unint_attrs.adb:16:7-16:53>
 ***************************************************************************
 
-Expr: <Id "Natural" test_unint_attrs.adb:16:20-16:27>
+Expr: <Id "Natural" test_unint_attrs.adb:16:21-16:28>
   references: <DefiningName __standard:5:11-5:18>
   type:       None
-Expr: <AttributeRef test_unint_attrs.adb:16:31-16:51>
+Expr: <AttributeRef test_unint_attrs.adb:16:32-16:52>
   references: None
   type:       <TypeDecl ["Universal_Int_Type_"] __standard:119:3-119:45>
-Expr: <Id "Float" test_unint_attrs.adb:16:31-16:36>
+Expr: <Id "Float" test_unint_attrs.adb:16:32-16:37>
   references: <DefiningName __standard:13:8-13:13>
   type:       <TypeDecl ["Float"] __standard:13:3-14:51>
-Expr: <Id "Model_Mantissa" test_unint_attrs.adb:16:37-16:51>
+Expr: <Id "Model_Mantissa" test_unint_attrs.adb:16:38-16:52>
   references: None
   type:       None
 
-Resolving xrefs for node <ObjectDecl ["D"] test_unint_attrs.adb:17:7-17:47>
+Resolving xrefs for node <ObjectDecl ["D"] test_unint_attrs.adb:17:7-17:48>
 ***************************************************************************
 
-Expr: <Id "Integer" test_unint_attrs.adb:17:20-17:27>
+Expr: <Id "Integer" test_unint_attrs.adb:17:21-17:28>
   references: <DefiningName __standard:4:8-4:15>
   type:       None
-Expr: <AttributeRef test_unint_attrs.adb:17:31-17:46>
+Expr: <AttributeRef test_unint_attrs.adb:17:32-17:47>
   references: None
   type:       <TypeDecl ["Universal_Int_Type_"] __standard:119:3-119:45>
-Expr: <DottedName test_unint_attrs.adb:17:31-17:37>
+Expr: <DottedName test_unint_attrs.adb:17:32-17:38>
   references: <DefiningName test_unint_attrs.adb:3:13-3:14>
   type:       <TypeDecl ["Integer"] __standard:4:3-4:54>
-Expr: <Id "Inst" test_unint_attrs.adb:17:31-17:35>
+Expr: <Id "Inst" test_unint_attrs.adb:17:32-17:36>
   references: <DefiningName test_unint_attrs.adb:5:4-5:8>
   type:       <TypeDecl ["R"] test_unint_attrs.adb:2:4-4:15>
-Expr: <Id "C" test_unint_attrs.adb:17:36-17:37>
+Expr: <Id "C" test_unint_attrs.adb:17:37-17:38>
   references: <DefiningName test_unint_attrs.adb:3:13-3:14>
   type:       <TypeDecl ["Integer"] __standard:4:3-4:54>
-Expr: <Id "Position" test_unint_attrs.adb:17:38-17:46>
+Expr: <Id "Position" test_unint_attrs.adb:17:39-17:47>
   references: None
   type:       None
 
-Resolving xrefs for node <ObjectDecl ["E"] test_unint_attrs.adb:18:7-18:50>
-***************************************************************************
+Resolving xrefs for node <ObjectDecl ["D1"] test_unint_attrs.adb:18:7-18:49>
+****************************************************************************
 
-Expr: <Id "Integer" test_unint_attrs.adb:18:20-18:27>
+Expr: <Id "Integer" test_unint_attrs.adb:18:21-18:28>
   references: <DefiningName __standard:4:8-4:15>
   type:       None
-Expr: <AttributeRef test_unint_attrs.adb:18:31-18:49>
+Expr: <AttributeRef test_unint_attrs.adb:18:32-18:48>
   references: None
   type:       <TypeDecl ["Universal_Int_Type_"] __standard:119:3-119:45>
-Expr: <Id "Arr" test_unint_attrs.adb:18:31-18:34>
+Expr: <DottedName test_unint_attrs.adb:18:32-18:38>
+  references: <DefiningName test_unint_attrs.adb:3:13-3:14>
+  type:       <TypeDecl ["Integer"] __standard:4:3-4:54>
+Expr: <Id "Inst" test_unint_attrs.adb:18:32-18:36>
+  references: <DefiningName test_unint_attrs.adb:5:4-5:8>
+  type:       <TypeDecl ["R"] test_unint_attrs.adb:2:4-4:15>
+Expr: <Id "C" test_unint_attrs.adb:18:37-18:38>
+  references: <DefiningName test_unint_attrs.adb:3:13-3:14>
+  type:       <TypeDecl ["Integer"] __standard:4:3-4:54>
+Expr: <Id "First_Bit" test_unint_attrs.adb:18:39-18:48>
+  references: None
+  type:       None
+
+Resolving xrefs for node <ObjectDecl ["D2"] test_unint_attrs.adb:19:7-19:48>
+****************************************************************************
+
+Expr: <Id "Integer" test_unint_attrs.adb:19:21-19:28>
+  references: <DefiningName __standard:4:8-4:15>
+  type:       None
+Expr: <AttributeRef test_unint_attrs.adb:19:32-19:47>
+  references: None
+  type:       <TypeDecl ["Universal_Int_Type_"] __standard:119:3-119:45>
+Expr: <DottedName test_unint_attrs.adb:19:32-19:38>
+  references: <DefiningName test_unint_attrs.adb:3:13-3:14>
+  type:       <TypeDecl ["Integer"] __standard:4:3-4:54>
+Expr: <Id "Inst" test_unint_attrs.adb:19:32-19:36>
+  references: <DefiningName test_unint_attrs.adb:5:4-5:8>
+  type:       <TypeDecl ["R"] test_unint_attrs.adb:2:4-4:15>
+Expr: <Id "C" test_unint_attrs.adb:19:37-19:38>
+  references: <DefiningName test_unint_attrs.adb:3:13-3:14>
+  type:       <TypeDecl ["Integer"] __standard:4:3-4:54>
+Expr: <Id "Last_Bit" test_unint_attrs.adb:19:39-19:47>
+  references: None
+  type:       None
+
+Resolving xrefs for node <ObjectDecl ["E"] test_unint_attrs.adb:20:7-20:51>
+***************************************************************************
+
+Expr: <Id "Integer" test_unint_attrs.adb:20:21-20:28>
+  references: <DefiningName __standard:4:8-4:15>
+  type:       None
+Expr: <AttributeRef test_unint_attrs.adb:20:32-20:50>
+  references: None
+  type:       <TypeDecl ["Universal_Int_Type_"] __standard:119:3-119:45>
+Expr: <Id "Arr" test_unint_attrs.adb:20:32-20:35>
   references: <DefiningName test_unint_attrs.adb:7:9-7:12>
   type:       <TypeDecl ["Arr"] test_unint_attrs.adb:7:4-7:54>
-Expr: <Id "Component_Size" test_unint_attrs.adb:18:35-18:49>
+Expr: <Id "Component_Size" test_unint_attrs.adb:20:36-20:50>
   references: None
   type:       None
 
-Resolving xrefs for node <ObjectDecl ["F"] test_unint_attrs.adb:19:7-19:45>
+Resolving xrefs for node <ObjectDecl ["F"] test_unint_attrs.adb:21:7-21:46>
 ***************************************************************************
 
-Expr: <Id "Integer" test_unint_attrs.adb:19:20-19:27>
+Expr: <Id "Integer" test_unint_attrs.adb:21:21-21:28>
   references: <DefiningName __standard:4:8-4:15>
   type:       None
-Expr: <AttributeRef test_unint_attrs.adb:19:31-19:44>
+Expr: <AttributeRef test_unint_attrs.adb:21:32-21:45>
   references: None
   type:       <TypeDecl ["Universal_Int_Type_"] __standard:119:3-119:45>
-Expr: <Id "Integer" test_unint_attrs.adb:19:31-19:38>
+Expr: <Id "Integer" test_unint_attrs.adb:21:32-21:39>
   references: <DefiningName __standard:4:8-4:15>
   type:       <TypeDecl ["Integer"] __standard:4:3-4:54>
-Expr: <Id "Width" test_unint_attrs.adb:19:39-19:44>
+Expr: <Id "Width" test_unint_attrs.adb:21:40-21:45>
   references: None
   type:       None
 
-Resolving xrefs for node <ObjectDecl ["G"] test_unint_attrs.adb:20:7-20:44>
+Resolving xrefs for node <ObjectDecl ["G"] test_unint_attrs.adb:22:7-22:45>
 ***************************************************************************
 
-Expr: <Id "Integer" test_unint_attrs.adb:20:20-20:27>
+Expr: <Id "Integer" test_unint_attrs.adb:22:21-22:28>
   references: <DefiningName __standard:4:8-4:15>
   type:       None
-Expr: <AttributeRef test_unint_attrs.adb:20:31-20:43>
+Expr: <AttributeRef test_unint_attrs.adb:22:32-22:44>
   references: None
   type:       <TypeDecl ["Universal_Int_Type_"] __standard:119:3-119:45>
-Expr: <Id "Float" test_unint_attrs.adb:20:31-20:36>
+Expr: <Id "Float" test_unint_attrs.adb:22:32-22:37>
   references: <DefiningName __standard:13:8-13:13>
   type:       <TypeDecl ["Float"] __standard:13:3-14:51>
-Expr: <Id "Digits" test_unint_attrs.adb:20:37-20:43>
+Expr: <Id "Digits" test_unint_attrs.adb:22:38-22:44>
   references: None
   type:       None
 
-Resolving xrefs for node <ObjectDecl ["H"] test_unint_attrs.adb:21:7-21:40>
+Resolving xrefs for node <ObjectDecl ["H"] test_unint_attrs.adb:23:7-23:41>
 ***************************************************************************
 
-Expr: <Id "Integer" test_unint_attrs.adb:21:20-21:27>
+Expr: <Id "Integer" test_unint_attrs.adb:23:21-23:28>
   references: <DefiningName __standard:4:8-4:15>
   type:       None
-Expr: <AttributeRef test_unint_attrs.adb:21:31-21:39>
+Expr: <AttributeRef test_unint_attrs.adb:23:32-23:40>
   references: None
   type:       <TypeDecl ["Universal_Int_Type_"] __standard:119:3-119:45>
-Expr: <Id "Volt" test_unint_attrs.adb:21:31-21:35>
+Expr: <Id "Volt" test_unint_attrs.adb:23:32-23:36>
   references: <DefiningName test_unint_attrs.adb:9:9-9:13>
   type:       None
-Expr: <Id "Aft" test_unint_attrs.adb:21:36-21:39>
+Expr: <Id "Aft" test_unint_attrs.adb:23:37-23:40>
   references: None
   type:       None
 
-Resolving xrefs for node <ObjectDecl ["I"] test_unint_attrs.adb:22:7-22:41>
+Resolving xrefs for node <ObjectDecl ["I"] test_unint_attrs.adb:24:7-24:42>
 ***************************************************************************
 
-Expr: <Id "Integer" test_unint_attrs.adb:22:20-22:27>
+Expr: <Id "Integer" test_unint_attrs.adb:24:21-24:28>
   references: <DefiningName __standard:4:8-4:15>
   type:       None
-Expr: <AttributeRef test_unint_attrs.adb:22:31-22:40>
+Expr: <AttributeRef test_unint_attrs.adb:24:32-24:41>
   references: None
   type:       <TypeDecl ["Universal_Int_Type_"] __standard:119:3-119:45>
-Expr: <Id "Volt" test_unint_attrs.adb:22:31-22:35>
+Expr: <Id "Volt" test_unint_attrs.adb:24:32-24:36>
   references: <DefiningName test_unint_attrs.adb:9:9-9:13>
   type:       <TypeDecl ["Volt"] test_unint_attrs.adb:9:4-9:48>
-Expr: <Id "Fore" test_unint_attrs.adb:22:36-22:40>
+Expr: <Id "Fore" test_unint_attrs.adb:24:37-24:41>
   references: None
   type:       None
 
-Resolving xrefs for node <ObjectDecl ["J"] test_unint_attrs.adb:23:7-23:41>
+Resolving xrefs for node <ObjectDecl ["J"] test_unint_attrs.adb:25:7-25:42>
 ***************************************************************************
 
-Expr: <Id "Natural" test_unint_attrs.adb:23:20-23:27>
+Expr: <Id "Natural" test_unint_attrs.adb:25:21-25:28>
   references: <DefiningName __standard:5:11-5:18>
   type:       None
-Expr: <AttributeRef test_unint_attrs.adb:23:31-23:40>
+Expr: <AttributeRef test_unint_attrs.adb:25:32-25:41>
   references: None
   type:       <TypeDecl ["Universal_Int_Type_"] __standard:119:3-119:45>
-Expr: <Id "M" test_unint_attrs.adb:23:31-23:32>
+Expr: <Id "M" test_unint_attrs.adb:25:32-25:33>
   references: <DefiningName test_unint_attrs.adb:11:9-11:10>
   type:       <TypeDecl ["M"] test_unint_attrs.adb:11:4-11:26>
-Expr: <Id "Modulus" test_unint_attrs.adb:23:33-23:40>
+Expr: <Id "Modulus" test_unint_attrs.adb:25:34-25:41>
   references: None
   type:       None
 
-Resolving xrefs for node <ObjectDecl ["K"] test_unint_attrs.adb:24:7-24:53>
+Resolving xrefs for node <ObjectDecl ["K"] test_unint_attrs.adb:26:7-26:54>
 ***************************************************************************
 
-Expr: <Id "Natural" test_unint_attrs.adb:24:20-24:27>
+Expr: <Id "Natural" test_unint_attrs.adb:26:21-26:28>
   references: <DefiningName __standard:5:11-5:18>
   type:       None
-Expr: <AttributeRef test_unint_attrs.adb:24:31-24:52>
+Expr: <AttributeRef test_unint_attrs.adb:26:32-26:53>
   references: None
   type:       <TypeDecl ["Universal_Int_Type_"] __standard:119:3-119:45>
-Expr: <Id "Standard" test_unint_attrs.adb:24:31-24:39>
+Expr: <Id "Standard" test_unint_attrs.adb:26:32-26:40>
   references: <DefiningName __standard:1:9-1:17>
   type:       None
-Expr: <Id "Address_Size" test_unint_attrs.adb:24:40-24:52>
+Expr: <Id "Address_Size" test_unint_attrs.adb:26:41-26:53>
   references: None
   type:       None
 
-Resolving xrefs for node <ObjectDecl ["L"] test_unint_attrs.adb:25:7-25:67>
+Resolving xrefs for node <ObjectDecl ["L"] test_unint_attrs.adb:27:7-27:68>
 ***************************************************************************
 
-Expr: <Id "Natural" test_unint_attrs.adb:25:20-25:27>
+Expr: <Id "Natural" test_unint_attrs.adb:27:21-27:28>
   references: <DefiningName __standard:5:11-5:18>
   type:       None
-Expr: <AttributeRef test_unint_attrs.adb:25:31-25:66>
+Expr: <AttributeRef test_unint_attrs.adb:27:32-27:67>
   references: None
   type:       <TypeDecl ["Universal_Int_Type_"] __standard:119:3-119:45>
-Expr: <Id "Standard" test_unint_attrs.adb:25:31-25:39>
+Expr: <Id "Standard" test_unint_attrs.adb:27:32-27:40>
   references: <DefiningName __standard:1:9-1:17>
   type:       None
-Expr: <Id "System_Allocator_Alignment" test_unint_attrs.adb:25:40-25:66>
+Expr: <Id "System_Allocator_Alignment" test_unint_attrs.adb:27:41-27:67>
   references: None
   type:       None
 
-Resolving xrefs for node <ObjectDecl ["M"] test_unint_attrs.adb:26:7-26:54>
+Resolving xrefs for node <ObjectDecl ["M"] test_unint_attrs.adb:28:7-28:55>
 ***************************************************************************
 
-Expr: <Id "Natural" test_unint_attrs.adb:26:20-26:27>
+Expr: <Id "Natural" test_unint_attrs.adb:28:21-28:28>
   references: <DefiningName __standard:5:11-5:18>
   type:       None
-Expr: <AttributeRef test_unint_attrs.adb:26:31-26:53>
+Expr: <AttributeRef test_unint_attrs.adb:28:32-28:54>
   references: None
   type:       <TypeDecl ["Universal_Int_Type_"] __standard:119:3-119:45>
-Expr: <Id "Inst" test_unint_attrs.adb:26:31-26:35>
+Expr: <Id "Inst" test_unint_attrs.adb:28:32-28:36>
   references: <DefiningName test_unint_attrs.adb:5:4-5:8>
   type:       <TypeDecl ["R"] test_unint_attrs.adb:2:4-4:15>
-Expr: <Id "Finalization_Size" test_unint_attrs.adb:26:36-26:53>
+Expr: <Id "Finalization_Size" test_unint_attrs.adb:28:37-28:54>
   references: None
   type:       None
 
-Resolving xrefs for node <ObjectDecl ["N"] test_unint_attrs.adb:27:7-27:49>
+Resolving xrefs for node <ObjectDecl ["N"] test_unint_attrs.adb:29:7-29:50>
 ***************************************************************************
 
-Expr: <Id "Natural" test_unint_attrs.adb:27:20-27:27>
+Expr: <Id "Natural" test_unint_attrs.adb:29:21-29:28>
   references: <DefiningName __standard:5:11-5:18>
   type:       None
-Expr: <AttributeRef test_unint_attrs.adb:27:31-27:48>
+Expr: <AttributeRef test_unint_attrs.adb:29:32-29:49>
   references: None
   type:       <TypeDecl ["Universal_Int_Type_"] __standard:119:3-119:45>
-Expr: <Id "R" test_unint_attrs.adb:27:31-27:32>
+Expr: <Id "R" test_unint_attrs.adb:29:32-29:33>
   references: <DefiningName test_unint_attrs.adb:2:9-2:10>
   type:       <TypeDecl ["R"] test_unint_attrs.adb:2:4-4:15>
-Expr: <Id "Descriptor_Size" test_unint_attrs.adb:27:33-27:48>
+Expr: <Id "Descriptor_Size" test_unint_attrs.adb:29:34-29:49>
   references: None
   type:       None
 
-Resolving xrefs for node <ObjectDecl ["O"] test_unint_attrs.adb:28:7-28:46>
+Resolving xrefs for node <ObjectDecl ["O"] test_unint_attrs.adb:30:7-30:47>
 ***************************************************************************
 
-Expr: <Id "Natural" test_unint_attrs.adb:28:20-28:27>
+Expr: <Id "Natural" test_unint_attrs.adb:30:21-30:28>
   references: <DefiningName __standard:5:11-5:18>
   type:       None
-Expr: <AttributeRef test_unint_attrs.adb:28:31-28:45>
+Expr: <AttributeRef test_unint_attrs.adb:30:32-30:46>
   references: None
   type:       <TypeDecl ["Universal_Int_Type_"] __standard:119:3-119:45>
-Expr: <Id "Inst" test_unint_attrs.adb:28:31-28:35>
+Expr: <Id "Inst" test_unint_attrs.adb:30:32-30:36>
   references: <DefiningName test_unint_attrs.adb:5:4-5:8>
   type:       <TypeDecl ["R"] test_unint_attrs.adb:2:4-4:15>
-Expr: <Id "Alignment" test_unint_attrs.adb:28:36-28:45>
+Expr: <Id "Alignment" test_unint_attrs.adb:30:37-30:46>
   references: None
   type:       None
 
-Resolving xrefs for node <NullStmt test_unint_attrs.adb:30:7-30:12>
+Resolving xrefs for node <NullStmt test_unint_attrs.adb:32:7-32:12>
 *******************************************************************
 
 

--- a/ada/testsuite/tests/name_resolution/unint_attrs/test_unint_attrs.adb
+++ b/ada/testsuite/tests/name_resolution/unint_attrs/test_unint_attrs.adb
@@ -11,21 +11,23 @@ procedure Test_Unint_Attrs is
    type M is mod 2 ** 16;
 begin
    declare
-      A : constant Natural := Float'Machine_Mantissa;
-      B : constant Natural := Float'Mantissa;
-      C : constant Natural := Float'Model_Mantissa;
-      D : constant Integer := Inst.C'Position;
-      E : constant Integer := Arr'Component_Size;
-      F : constant Integer := Integer'Width;
-      G : constant Integer := Float'Digits;
-      H : constant Integer := Volt'Aft;
-      I : constant Integer := Volt'Fore;
-      J : constant Natural := M'Modulus;
-      K : constant Natural := Standard'Address_Size;
-      L : constant Natural := Standard'System_Allocator_Alignment;
-      M : constant Natural := Inst'Finalization_Size;
-      N : constant Natural := R'Descriptor_Size;
-      O : constant Natural := Inst'Alignment;
+      A  : constant Natural := Float'Machine_Mantissa;
+      B  : constant Natural := Float'Mantissa;
+      C  : constant Natural := Float'Model_Mantissa;
+      D  : constant Integer := Inst.C'Position;
+      D1 : constant Integer := Inst.C'First_Bit;
+      D2 : constant Integer := Inst.C'Last_Bit;
+      E  : constant Integer := Arr'Component_Size;
+      F  : constant Integer := Integer'Width;
+      G  : constant Integer := Float'Digits;
+      H  : constant Integer := Volt'Aft;
+      I  : constant Integer := Volt'Fore;
+      J  : constant Natural := M'Modulus;
+      K  : constant Natural := Standard'Address_Size;
+      L  : constant Natural := Standard'System_Allocator_Alignment;
+      M  : constant Natural := Inst'Finalization_Size;
+      N  : constant Natural := R'Descriptor_Size;
+      O  : constant Natural := Inst'Alignment;
    begin
       null;
    end;

--- a/ada/testsuite/tests/properties/failsafe_referenced_def_name/test.adb
+++ b/ada/testsuite/tests/properties/failsafe_referenced_def_name/test.adb
@@ -1,0 +1,18 @@
+procedure Test is
+   function Foo (A : Integer) return Float;
+
+
+   A : Float :=
+     Foo --% $node.p_failsafe_referenced_def_name(True)
+      (12);
+
+   B : Integer :=
+     Foo --% $node.p_failsafe_referenced_def_name(True)
+       (12);
+
+   C : Integer :=
+     Barz --% $node.p_failsafe_referenced_def_name(True)
+       (12);
+begin
+   null;
+end Test;

--- a/ada/testsuite/tests/properties/failsafe_referenced_def_name/test.out
+++ b/ada/testsuite/tests/properties/failsafe_referenced_def_name/test.out
@@ -1,0 +1,10 @@
+Eval 'node.p_failsafe_referenced_def_name(True)' on node <Id "Foo" test.adb:6:6-6:9>
+Result: <RefdDef def_name=<DefiningName test.adb:2:13-2:16> kind=precise>
+
+Eval 'node.p_failsafe_referenced_def_name(True)' on node <Id "Foo" test.adb:10:6-10:9>
+Result: <RefdDef def_name=<DefiningName test.adb:2:13-2:16> kind=imprecise>
+
+Eval 'node.p_failsafe_referenced_def_name(True)' on node <Id "Barz" test.adb:14:6-14:10>
+Result: <RefdDef def_name=None kind=error>
+
+

--- a/ada/testsuite/tests/properties/failsafe_referenced_def_name/test.yaml
+++ b/ada/testsuite/tests/properties/failsafe_referenced_def_name/test.yaml
@@ -1,0 +1,2 @@
+driver: inline-playground
+input_sources: [test.adb]

--- a/ada/testsuite/tests/properties/find_all_refs_imprecise/main.adb
+++ b/ada/testsuite/tests/properties/find_all_refs_imprecise/main.adb
@@ -1,0 +1,27 @@
+procedure Main is
+   package Foo is
+      type T is null record;
+      pragma Find_All_References (Any, Imprecise_Fallback => True);
+
+      A : T := (null record);
+   end Foo;
+
+
+   package Bar is
+      function Baz (A : Integer) return Float;
+      pragma Find_All_References (Any, Imprecise_Fallback => True);
+   end Bar;
+
+   package body Bar is
+      A : Float := Baz (12);
+      B : Integer := Baz (12);
+      --  This one will resolve to function Baz in imprecise mode
+   end Bar;
+
+   A : Float := Lol.Bar.Baz (12, Poo);
+   --  Resolution of this statement will fail even in imprecise_fallback mode
+   --  because there is no `Baz` visible here. Even so, it shouldn't crash
+   --  find_all_references for Baz.
+begin
+   null;
+end Main;

--- a/ada/testsuite/tests/properties/find_all_refs_imprecise/test.out
+++ b/ada/testsuite/tests/properties/find_all_refs_imprecise/test.out
@@ -1,0 +1,9 @@
+Analyzing main.adb
+##################
+
+References to T (main.adb, 3:12-3:13)
+   A : T := (null record); (main.adb, 6:7-6:30)
+References to Baz (main.adb, 11:16-11:19)
+   A : Float := Baz (12); (main.adb, 16:7-16:29)
+   B : Integer := Baz (12); (main.adb, 17:7-17:31)
+Done.

--- a/ada/testsuite/tests/properties/find_all_refs_imprecise/test.yaml
+++ b/ada/testsuite/tests/properties/find_all_refs_imprecise/test.yaml
@@ -1,0 +1,2 @@
+driver: name-resolution
+input_sources: [main.adb]

--- a/ada/testsuite/tests/properties/is_dispatching_call/test.out
+++ b/ada/testsuite/tests/properties/is_dispatching_call/test.out
@@ -1,28 +1,28 @@
 Analyzing references of Foo_1 (<DefiningName test.adb:6:17-6:22>)
-  Reference <Id "Foo_1" test.adb:39:4-39:9> is a dispatching call.
-  Reference <Id "Foo_1" test.adb:45:6-45:11> is a dispatching call.
-  Reference <Id "Foo_1" test.adb:49:4-49:9> is not a dispatching call.
-  Reference <Id "Foo_1" test.adb:55:6-55:11> is not a dispatching call.
+  Reference <RefResult ref=<Id "Foo_1" test.adb:39:4-39:9> kind=precise> is a dispatching call.
+  Reference <RefResult ref=<Id "Foo_1" test.adb:45:6-45:11> kind=precise> is a dispatching call.
+  Reference <RefResult ref=<Id "Foo_1" test.adb:49:4-49:9> kind=precise> is not a dispatching call.
+  Reference <RefResult ref=<Id "Foo_1" test.adb:55:6-55:11> kind=precise> is not a dispatching call.
 Analyzing references of Foo_2 (<DefiningName test.adb:7:17-7:22>)
-  Reference <Id "Foo_2" test.adb:40:4-40:9> is a dispatching call.
-  Reference <Id "Foo_2" test.adb:50:4-50:9> is not a dispatching call.
+  Reference <RefResult ref=<Id "Foo_2" test.adb:40:4-40:9> kind=precise> is a dispatching call.
+  Reference <RefResult ref=<Id "Foo_2" test.adb:50:4-50:9> kind=precise> is not a dispatching call.
 Analyzing references of Foo_3 (<DefiningName test.adb:8:17-8:22>)
-  Reference <Id "Foo_3" test.adb:59:4-59:9> is a dispatching call.
-  Reference <Id "Foo_3" test.adb:60:4-60:9> is not a dispatching call.
-  Reference <Id "Foo_3" test.adb:61:6-61:11> is a dispatching call.
-  Reference <Id "Foo_3" test.adb:62:6-62:11> is not a dispatching call.
+  Reference <RefResult ref=<Id "Foo_3" test.adb:59:4-59:9> kind=precise> is a dispatching call.
+  Reference <RefResult ref=<Id "Foo_3" test.adb:60:4-60:9> kind=precise> is not a dispatching call.
+  Reference <RefResult ref=<Id "Foo_3" test.adb:61:6-61:11> kind=precise> is a dispatching call.
+  Reference <RefResult ref=<Id "Foo_3" test.adb:62:6-62:11> kind=precise> is not a dispatching call.
 Analyzing references of Bar_1 (<DefiningName test.adb:10:16-10:21>)
-  Reference <Id "Bar_1" test.adb:41:9-41:14> is a dispatching call.
-  Reference <Id "Bar_1" test.adb:46:11-46:16> is a dispatching call.
-  Reference <Id "Bar_1" test.adb:51:9-51:14> is not a dispatching call.
-  Reference <Id "Bar_1" test.adb:56:11-56:16> is not a dispatching call.
+  Reference <RefResult ref=<Id "Bar_1" test.adb:41:9-41:14> kind=precise> is a dispatching call.
+  Reference <RefResult ref=<Id "Bar_1" test.adb:46:11-46:16> kind=precise> is a dispatching call.
+  Reference <RefResult ref=<Id "Bar_1" test.adb:51:9-51:14> kind=precise> is not a dispatching call.
+  Reference <RefResult ref=<Id "Bar_1" test.adb:56:11-56:16> kind=precise> is not a dispatching call.
 Analyzing references of Bar_2 (<DefiningName test.adb:11:16-11:21>)
-  Reference <Id "Bar_2" test.adb:42:9-42:14> is a dispatching call.
-  Reference <Id "Bar_2" test.adb:47:11-47:16> is a dispatching call.
-  Reference <Id "Bar_2" test.adb:52:9-52:14> is not a dispatching call.
-  Reference <Id "Bar_2" test.adb:57:11-57:16> is not a dispatching call.
+  Reference <RefResult ref=<Id "Bar_2" test.adb:42:9-42:14> kind=precise> is a dispatching call.
+  Reference <RefResult ref=<Id "Bar_2" test.adb:47:11-47:16> kind=precise> is a dispatching call.
+  Reference <RefResult ref=<Id "Bar_2" test.adb:52:9-52:14> kind=precise> is not a dispatching call.
+  Reference <RefResult ref=<Id "Bar_2" test.adb:57:11-57:16> kind=precise> is not a dispatching call.
 Analyzing references of Foo_Bar (<DefiningName test.adb:13:16-13:23>)
-  Reference <Id "Foo_Bar" test.adb:43:9-43:16> is a dispatching call.
-  Reference <Id "Foo_Bar" test.adb:53:9-53:16> is not a dispatching call.
+  Reference <RefResult ref=<Id "Foo_Bar" test.adb:43:9-43:16> kind=precise> is a dispatching call.
+  Reference <RefResult ref=<Id "Foo_Bar" test.adb:53:9-53:16> kind=precise> is not a dispatching call.
 
 Done

--- a/ada/testsuite/tests/properties/is_dispatching_call/test.py
+++ b/ada/testsuite/tests/properties/is_dispatching_call/test.py
@@ -13,10 +13,10 @@ for subp in root_pkg.findall((lal.NullSubpDecl, lal.ExprFunction)):
     name = subp.f_subp_spec.f_subp_name
     print("Analyzing references of {} ({})".format(name.text, name))
     for ref in name.p_find_all_references([u]):
-        if ref.p_is_call:
+        if ref.ref.p_is_call:
             print("  Reference {} is {}".format(
                 ref,
-                "a dispatching call." if ref.p_is_dispatching_call()
+                "a dispatching call." if ref.ref.p_is_dispatching_call()
                 else "not a dispatching call."
             ))
 

--- a/ada/testsuite/tests/properties/is_write_reference/test.out
+++ b/ada/testsuite/tests/properties/is_write_reference/test.out
@@ -1,48 +1,48 @@
 == test.adb ==
 Analyzing references of Main (<DefiningName test.adb:1:11-1:15>)
-  Reference <Id "Main" test.adb:26:5-26:9> is not a write reference.
+  Reference <RefResult ref=<Id "Main" test.adb:26:5-26:9> kind=precise> is not a write reference.
 Analyzing references of Arr (<DefiningName test.adb:2:9-2:12>)
-  Reference <Id "Arr" test.adb:4:11-4:14> is not a write reference.
-  Reference <Id "Arr" test.adb:8:26-8:29> is not a write reference.
-  Reference <Id "Arr" test.adb:8:39-8:42> is not a write reference.
-  Reference <Id "Arr" test.adb:13:8-13:11> is not a write reference.
+  Reference <RefResult ref=<Id "Arr" test.adb:4:11-4:14> kind=precise> is not a write reference.
+  Reference <RefResult ref=<Id "Arr" test.adb:8:26-8:29> kind=precise> is not a write reference.
+  Reference <RefResult ref=<Id "Arr" test.adb:8:39-8:42> kind=precise> is not a write reference.
+  Reference <RefResult ref=<Id "Arr" test.adb:13:8-13:11> kind=precise> is not a write reference.
 Analyzing references of Rec (<DefiningName test.adb:3:9-3:12>)
-  Reference <Id "Rec" test.adb:6:52-6:55> is not a write reference.
-  Reference <Id "Rec" test.adb:16:8-16:11> is not a write reference.
+  Reference <RefResult ref=<Id "Rec" test.adb:6:52-6:55> kind=precise> is not a write reference.
+  Reference <RefResult ref=<Id "Rec" test.adb:16:8-16:11> kind=precise> is not a write reference.
 Analyzing references of A (<DefiningName test.adb:4:7-4:8>)
-  Reference <Id "A" test.adb:23:6-23:7> is a write reference.
-  Reference <Id "A" test.adb:24:10-24:11> is a write reference.
-  Reference <Id "A" test.adb:24:25-24:26> is not a write reference.
-  Reference <Id "A" test.adb:25:15-25:16> is not a write reference.
-  Reference <Id "A" test.adb:25:24-25:25> is a write reference.
+  Reference <RefResult ref=<Id "A" test.adb:23:6-23:7> kind=precise> is a write reference.
+  Reference <RefResult ref=<Id "A" test.adb:24:10-24:11> kind=precise> is a write reference.
+  Reference <RefResult ref=<Id "A" test.adb:24:25-24:26> kind=precise> is not a write reference.
+  Reference <RefResult ref=<Id "A" test.adb:25:15-25:16> kind=precise> is not a write reference.
+  Reference <RefResult ref=<Id "A" test.adb:25:24-25:25> kind=precise> is a write reference.
 Analyzing references of Rec_Arr (<DefiningName test.adb:6:9-6:16>)
-  Reference <Id "Rec_Arr" test.adb:17:8-17:15> is not a write reference.
+  Reference <RefResult ref=<Id "Rec_Arr" test.adb:17:8-17:15> kind=precise> is not a write reference.
 Analyzing references of Foo (<DefiningName test.adb:8:14-8:17>)
-  Reference <Id "Foo" test.adb:11:8-11:11> is not a write reference.
-  Reference <Id "Foo" test.adb:21:4-21:7> is not a write reference.
-  Reference <Id "Foo" test.adb:25:4-25:7> is not a write reference.
+  Reference <RefResult ref=<Id "Foo" test.adb:11:8-11:11> kind=precise> is not a write reference.
+  Reference <RefResult ref=<Id "Foo" test.adb:21:4-21:7> kind=precise> is not a write reference.
+  Reference <RefResult ref=<Id "Foo" test.adb:25:4-25:7> kind=precise> is not a write reference.
 Analyzing references of A (<DefiningName test.adb:8:19-8:20>)
 Analyzing references of B (<DefiningName test.adb:8:31-8:32>)
 Analyzing references of X (<DefiningName test.adb:13:4-13:5>)
-  Reference <Id "X" test.adb:19:4-19:5> is a write reference.
-  Reference <Id "X" test.adb:20:4-20:5> is a write reference.
-  Reference <Id "X" test.adb:21:9-21:10> is not a write reference.
-  Reference <Id "X" test.adb:21:12-21:13> is a write reference.
-  Reference <Id "X" test.adb:23:11-23:12> is not a write reference.
+  Reference <RefResult ref=<Id "X" test.adb:19:4-19:5> kind=precise> is a write reference.
+  Reference <RefResult ref=<Id "X" test.adb:20:4-20:5> kind=precise> is a write reference.
+  Reference <RefResult ref=<Id "X" test.adb:21:9-21:10> kind=precise> is not a write reference.
+  Reference <RefResult ref=<Id "X" test.adb:21:12-21:13> kind=precise> is a write reference.
+  Reference <RefResult ref=<Id "X" test.adb:23:11-23:12> kind=precise> is not a write reference.
 Analyzing references of Y (<DefiningName test.adb:14:4-14:5>)
-  Reference <Id "Y" test.adb:15:26-15:27> is a write reference.
-  Reference <Id "Y" test.adb:19:20-19:21> is not a write reference.
-  Reference <Id "Y" test.adb:20:13-20:14> is not a write reference.
-  Reference <Id "Y" test.adb:25:12-25:13> is not a write reference.
-  Reference <Id "Y" test.adb:25:21-25:22> is not a write reference.
+  Reference <RefResult ref=<Id "Y" test.adb:15:26-15:27> kind=precise> is a write reference.
+  Reference <RefResult ref=<Id "Y" test.adb:19:20-19:21> kind=precise> is not a write reference.
+  Reference <RefResult ref=<Id "Y" test.adb:20:13-20:14> kind=precise> is not a write reference.
+  Reference <RefResult ref=<Id "Y" test.adb:25:12-25:13> kind=precise> is not a write reference.
+  Reference <RefResult ref=<Id "Y" test.adb:25:21-25:22> kind=precise> is not a write reference.
 Analyzing references of Z (<DefiningName test.adb:15:4-15:5>)
-  Reference <Id "Z" test.adb:22:4-22:5> is not a write reference.
+  Reference <RefResult ref=<Id "Z" test.adb:22:4-22:5> kind=precise> is not a write reference.
 Analyzing references of V (<DefiningName test.adb:16:4-16:5>)
-  Reference <Id "V" test.adb:23:4-23:5> is a write reference.
+  Reference <RefResult ref=<Id "V" test.adb:23:4-23:5> kind=precise> is a write reference.
 Analyzing references of W (<DefiningName test.adb:17:4-17:5>)
-  Reference <Id "W" test.adb:24:4-24:5> is a write reference.
-  Reference <Id "W" test.adb:24:19-24:20> is not a write reference.
-  Reference <Id "W" test.adb:25:9-25:10> is not a write reference.
-  Reference <Id "W" test.adb:25:18-25:19> is a write reference.
+  Reference <RefResult ref=<Id "W" test.adb:24:4-24:5> kind=precise> is a write reference.
+  Reference <RefResult ref=<Id "W" test.adb:24:19-24:20> kind=precise> is not a write reference.
+  Reference <RefResult ref=<Id "W" test.adb:25:9-25:10> kind=precise> is not a write reference.
+  Reference <RefResult ref=<Id "W" test.adb:25:18-25:19> kind=precise> is a write reference.
 
 Done

--- a/ada/testsuite/tests/properties/is_write_reference/test.py
+++ b/ada/testsuite/tests/properties/is_write_reference/test.py
@@ -15,7 +15,7 @@ for filename in sys.argv[1:]:
         for ref in name.p_find_all_references([u]):
             print("  Reference {} is {}".format(
                 ref,
-                "a write reference." if ref.p_is_write_reference()
+                "a write reference." if ref.ref.p_is_write_reference()
                 else "not a write reference."
             ))
 

--- a/user_manual/changes/T330-005.yaml
+++ b/user_manual/changes/T330-005.yaml
@@ -1,5 +1,10 @@
 type: api-change
-title: ``DefiningName.find_all_references/calls`` returns ``RefResult`` array
+
+title: |
+    ``DefiningName.find_all_refs/calls`` returns ``RefResult`` array
+
+short_title: |
+    ``find_all_refs/calls`` returns ``RefResult`` array
 
 description: |
     ``DefiningName.find_all_references/calls`` returns ``RefResult`` array,

--- a/user_manual/changes/T330-005.yaml
+++ b/user_manual/changes/T330-005.yaml
@@ -1,0 +1,14 @@
+type: api-change
+title: ``DefiningName.find_all_references/calls`` returns ``RefResult`` array
+
+description: |
+    ``DefiningName.find_all_references/calls`` returns ``RefResult`` array,
+    which contains the information of whether the reference was obtained via
+    precise or imprecise resolution.
+
+    Additionally, exceptions shouldn't be raised as part of the normal control
+    flow of those properties, and a name resolution failure won't make them
+    stop searching.
+
+
+date: 2020-04-02

--- a/user_manual/changes/T402-020.yaml
+++ b/user_manual/changes/T402-020.yaml
@@ -1,0 +1,16 @@
+type: new-feature
+title: Add failsafe ``referenced_decl/name`` properties
+
+description: |
+    Add ``Name.failsafe_referenced_decl`` and
+    ``Name.failsafe_referenced_def_name`` properties. Those properties act like
+    their non failsafe counterpart, except that they'll never raise an
+    exception, and they will track in the result whether it was found through
+    precise or imprecise resolution.
+
+    Note that for most purposes, those are purely better version of
+    `referenced_decl`` and ``referenced_defining_name``, should be used in
+    priority, and might replace those in a future version of LAL.
+
+date: 2020-04-02
+

--- a/user_manual/conf.py
+++ b/user_manual/conf.py
@@ -364,7 +364,7 @@ def setup(app):
 
     rst_content = subprocess.check_output([
         sys.executable, P.join('changes', 'process_changes.py'),
-        'create-rst'
+        'rst'
     ])
 
     with open(P.join(P.dirname(P.abspath(__file__)), 'api_changes.rst'),


### PR DESCRIPTION
* Fix `find_all_references` & related imprecise_fallback mode
* Introduce failsafe versions of some xref properties
* Make `get_completion` return `CompletionItem`s, to allow some metadata along the items
* Store `is_dot_call` inside `CompletionItem`s 
* Some improvements to `process_changes.py`