### PR TITLE
T510-001: Rework filter_is_imported_by.

### DIFF
--- a/ada/testsuite/tests/properties/find_all_references/a-child.adb
+++ b/ada/testsuite/tests/properties/find_all_references/a-child.adb
@@ -1,0 +1,5 @@
+procedure A.Child is
+   Y : Integer := X;
+begin
+   null;
+end A.Child;

--- a/ada/testsuite/tests/properties/find_all_references/test.out
+++ b/ada/testsuite/tests/properties/find_all_references/test.out
@@ -1,6 +1,9 @@
 Analyzing a.ads
 ###############
 
+Analyzing a-child.adb
+#####################
+
 Analyzing a.adb
 ###############
 
@@ -27,6 +30,7 @@ Analyzing pragmas.ads
 
 References to A (a.ads, 1:9-1:10)
    A (a.ads, 19:5-19:6)
+   A.Child (a-child.adb, 1:11-1:18)
    package body A is (a.adb, 1:1-14:7)
    A (a.adb, 14:5-14:6)
    with A; (b.ads, 1:1-1:8)
@@ -46,6 +50,7 @@ References to "+" (a.ads, 13:13-13:16)
    "+" (a.adb, 13:8-13:11)
    return +B.Make_Rec_1 (2); (c.adb, 6:7-6:32)
 References to X (a.ads, 17:4-17:5)
+   Y : Integer := X; (a-child.adb, 2:4-2:21)
    Y : Integer := X; (a.adb, 3:7-3:24)
 References to Y (a.adb, 3:7-3:8)
    return Y; (a.adb, 6:7-6:16)

--- a/ada/testsuite/tests/properties/find_all_references/test.yaml
+++ b/ada/testsuite/tests/properties/find_all_references/test.yaml
@@ -1,2 +1,2 @@
 driver: name-resolution
-input_sources: [a.ads, a.adb, b.ads, b.adb, c.ads, c.adb, d.ads, d.adb, pragmas.ads]
+input_sources: [a.ads, a-child.adb, a.adb, b.ads, b.adb, c.ads, c.adb, d.ads, d.adb, pragmas.ads]

--- a/user_manual/changes/T510-001.yaml
+++ b/user_manual/changes/T510-001.yaml
@@ -1,0 +1,7 @@
+type: bugfix
+title: Missed child units during ``find_all_references``
+description: |
+    Until now, child units defining a subprogram body at the top-level without
+    a corresponding specification unit would be "forgotten" in calls to
+    find_all_references & co. This is now fixed.
+date: 2020-05-12


### PR DESCRIPTION
In particular, use the recently introduced p_imported_units property to
discover "with"ed units. This removes a duplicate logic we had for discovering
those, and removes a bug where body-only top-level subprograms defined as child
packages would be erroneously filtered by p_filter_is_imported_by.