### PR TITLE
T513-013: Implement python method Name.doc_name

### DIFF
--- a/ada/extensions/python
+++ b/ada/extensions/python
@@ -9,18 +9,35 @@ def token_match(self, other):
 
 
 @property
-def full_name(n):
+def doc_name(n):
     """
-    Return a nicely pretty printed name for any expr that is only formed of
-    DottedName and Identifier instances.
-    """
-    if isinstance(n, DottedName):
-        return "{}.{}".format(n.f_prefix.full_name, n.f_suffix.full_name)
-    elif isinstance(n, BaseId):
-        return n.text
-    else:
-        raise Exception("Wrong type for name: {}".format(type(n)))
+    Format this name to be a readable qualified name for the entity designated
+    by it. Meant to be used in documentation context.
 
+    If the entity is local, it will return the relative name. If it is
+    non-local, return the shortest qualified name not taking use clauses into
+    account.
+
+    .. NOTE:: This is a python specific method, because for the moment this is
+        not conveniently implementable directly as a libadalang property.
+    """
+    if n.p_is_defining and not n.is_a(DefiningName):
+        n = n.p_enclosing_defining_name
+
+    ref_decl = n.p_basic_decl if n.p_is_defining else n.p_referenced_decl()
+    ref_decl_fqn = ref_decl.p_fully_qualified_name
+
+    enclosing_package = next((p for p in n.parents if p.is_a(BasePackageDecl)), None)
+
+    if enclosing_package is None or enclosing_package == ref_decl:
+        return ref_decl_fqn
+
+    enclosing_decl_fqn = enclosing_package.p_fully_qualified_name
+
+    if ref_decl_fqn.lower().startswith(enclosing_decl_fqn.lower()):
+        return ref_decl_fqn[len(enclosing_decl_fqn):].strip(".")
+    else:
+        return ref_decl_fqn
 
 Token.match = token_match
-Name.full_name = full_name
+Name.doc_name = doc_name

--- a/ada/testsuite/tests/properties/python_doc_name/test.adb
+++ b/ada/testsuite/tests/properties/python_doc_name/test.adb
@@ -1,0 +1,26 @@
+package Pkg is
+   type My_String is new String;
+
+   package Child_Pkg is
+      type My_Int is new Integer;
+   end Child_Pkg;
+
+   use Child_Pkg;
+
+   procedure Foo (I : My_Int);
+   --% $node.findall(lal.Name)[-1].doc_name
+end Pkg;
+
+with Pkg; use Pkg;
+package Pkg2 is
+   type My_Other_String is new String;
+
+   procedure Foo (S : Pkg.My_String);
+   --% $node.findall(lal.Name)[-1].doc_name
+
+   procedure Bar (S : My_String);
+   --% $node.findall(lal.Name)[-1].doc_name
+
+   procedure Baz (S : Pkg2.My_Other_String);
+   --% $node.findall(lal.Name)[-1].doc_name
+end Pkg2;

--- a/ada/testsuite/tests/properties/python_doc_name/test.out
+++ b/ada/testsuite/tests/properties/python_doc_name/test.out
@@ -1,0 +1,13 @@
+Eval 'node.findall(lal.Name)[-1].doc_name' on node <SubpDecl ["Foo"] test.adb:10:4-10:31>
+Result: 'Child_Pkg.My_Int'
+
+Eval 'node.findall(lal.Name)[-1].doc_name' on node <SubpDecl ["Foo"] test.adb:18:4-18:38>
+Result: 'Pkg.My_String'
+
+Eval 'node.findall(lal.Name)[-1].doc_name' on node <SubpDecl ["Bar"] test.adb:21:4-21:34>
+Result: 'Pkg.My_String'
+
+Eval 'node.findall(lal.Name)[-1].doc_name' on node <SubpDecl ["Baz"] test.adb:24:4-24:45>
+Result: 'My_Other_String'
+
+

--- a/ada/testsuite/tests/properties/python_doc_name/test.yaml
+++ b/ada/testsuite/tests/properties/python_doc_name/test.yaml
@@ -1,0 +1,2 @@
+driver: inline-playground
+input_sources: [test.adb]


### PR DESCRIPTION
Not implemented in Libadalang proper due to missing DSL features in
langkit.

Also remove python methode Name.full_name, not useful in the current
state of things.