### PR TITLE
T811-021 nameres: improve resources reporting

### DIFF
--- a/utils/nameres.gpr
+++ b/utils/nameres.gpr
@@ -23,6 +23,11 @@ project Nameres is
    end Builder;
 
    package Compiler is
+      --  Nameres is using GNATCOLL.Memory to track memory usage:
+      --  -gnatg is needed to compile it. Other options are useful for
+      --  performance.
+      for Switches ("s-memory.adb") use ("-g", "-O2", "-gnatpg");
+
       case Build_Mode is
          when "dev" =>
             for Default_Switches ("Ada") use ("-g", "-O0", "-gnata");


### PR DESCRIPTION
When --time is passed, report the total time at end of processing.

Add a switch --memory which will print the memory footprint at
the end of processing.