### PR TITLE
T706-023: Fix requeue stmt equation.

### DIFF
--- a/ada/language/ast.py
+++ b/ada/language/ast.py
@@ -13328,7 +13328,7 @@ class RequeueStmt(SimpleStmt):
                 # because _.at(0) does not unparse in a way that LKT can parse.
                 first_param=ce._.params.as_array.at(0)._.expr:
 
-                Bind(name.ref_var, e) & first_param.then(
+                first_param.then(
                     lambda p: p.sub_equation & fam_type.then(
                         lambda eft: Self.type_bind_val(p.type_var, eft),
                         LogicTrue()

--- a/ada/testsuite/tests/name_resolution/requeue_stmt/test.out
+++ b/ada/testsuite/tests/name_resolution/requeue_stmt/test.out
@@ -1,11 +1,11 @@
 Analyzing test_requeue.adb
 ##########################
 
-Resolving xrefs for node <RequeueStmt test_requeue.adb:29:13-29:34>
+Resolving xrefs for node <RequeueStmt test_requeue.adb:34:13-34:34>
 *******************************************************************
 
-Expr: <Id "Wait_For_Get" test_requeue.adb:29:21-29:33>
-  references: <DefiningName test_requeue.adb:14:13-14:25>
+Expr: <Id "Wait_For_Get" test_requeue.adb:34:21-34:33>
+  references: <DefiningName test_requeue.adb:22:13-22:25>
   type:       None
 
 

--- a/ada/testsuite/tests/name_resolution/requeue_stmt/test_requeue.adb
+++ b/ada/testsuite/tests/name_resolution/requeue_stmt/test_requeue.adb
@@ -19,6 +19,11 @@ procedure ProducerConsumer_Test is
    end Producer_Consumer;
 
    protected body Producer_Consumer is
+      entry Wait_For_Get(Value_Get : out Natural) when Data_Available is
+      begin
+         Value_Get := The_Data;
+         Data_Available := False;
+      end Wait_For_Get;
 
       entry Get_Data (Value_Get : out Natural) when true is
       begin
@@ -30,12 +35,6 @@ procedure ProducerConsumer_Test is
             pragma Test_Statement;
          end if;
       end Get_Data;
-
-      entry Wait_For_Get(Value_Get : out Natural) when Data_Available is
-      begin
-         Value_Get := The_Data;
-         Data_Available := False;
-      end Wait_For_Get;
 
       procedure Put_Data(Value_Put : in Natural) is
       begin


### PR DESCRIPTION
An assumption was previously made during the construction of requeue
statements' equations that the requeued name should reference an EntryDecl,
thus filtering off entry bodies.

This was not a problem until recent improvements made on entry navigation
(done under this ticket), where entry bodies were now added to lexical
envs and became thus visible. This fix consists in not binding twice the
requeued name.

The simple change in the test consists in moving the body of the
requeued entry such that it is visible at the site of the requeue stmt.
This shows that even though the entry body is visible, the requeue stmt
is correctly resolved.