### PR TITLE
T813-011 Add a -U/--recursive option to Helpers

### DIFF
--- a/ada/extensions/src/libadalang-helpers.adb
+++ b/ada/extensions/src/libadalang-helpers.adb
@@ -113,9 +113,13 @@ package body Libadalang.Helpers is
       --  Abort_App.
 
       procedure List_Sources_From_Project
-        (Project : Project_Tree'Class; Files : out String_Vectors.Vector);
+        (Project             : Project_Tree'Class;
+         Include_Subprojects : Boolean;
+         Files               : out String_Vectors.Vector);
       --  Append the list of all source files in Project's root project to
-      --  Files.
+      --  Files. If Include_Subprojects is True, include all source files
+      --  in the imported projects, excluding those that are externally
+      --  built.
 
       function Files_From_Args
         (Files : out String_Vectors.Vector) return Boolean;
@@ -263,13 +267,18 @@ package body Libadalang.Helpers is
       -------------------------------
 
       procedure List_Sources_From_Project
-        (Project : Project_Tree'Class; Files : out String_Vectors.Vector)
+        (Project             : Project_Tree'Class;
+         Include_Subprojects : Boolean;
+         Files               : out String_Vectors.Vector)
       is
          --  Get a sorted list of source files in Project's root project.
          --  Sorting gets the output deterministic and thus helps
          --  reproducibility.
 
-         List : File_Array_Access := Project.Root_Project.Source_Files;
+         List : File_Array_Access :=
+                  Project.Root_Project.Source_Files
+                    (Recursive                => Include_Subprojects,
+                     Include_Externally_Built => False);
       begin
          Sort (List.all);
 
@@ -478,7 +487,10 @@ package body Libadalang.Helpers is
                Env           => Env);
             UFP := Project_To_Provider (Project);
             if not Files_From_Args (Files) then
-               List_Sources_From_Project (Project.all, Files);
+               List_Sources_From_Project
+                 (Project.all,
+                  Args.Process_Full_Project_Tree.Get,
+                  Files);
             end if;
 
             --  Fill in the provider

--- a/ada/extensions/src/libadalang-helpers.ads
+++ b/ada/extensions/src/libadalang-helpers.ads
@@ -205,6 +205,11 @@ package Libadalang.Helpers is
             Default_Val => Null_Unbounded_String,
             Help        => "Project file to use");
 
+         package Process_Full_Project_Tree is new Parse_Flag
+           (Parser, "-U", "--recursive",
+            Help => "Process all units in the project tree, " &
+              "excluding externally built projects");
+
          package Scenario_Vars is new Parse_Option_List
            (Parser, Short => "-X", Long => "--scenario-variable",
             Arg_Type      => Unbounded_String,

--- a/ada/testsuite/tests/ada_api/app/recursive/main.adb
+++ b/ada/testsuite/tests/ada_api/app/recursive/main.adb
@@ -1,0 +1,25 @@
+with Ada.Text_IO; use Ada.Text_IO;
+
+with Libadalang.Analysis; use Libadalang.Analysis;
+with Libadalang.Helpers;  use Libadalang.Helpers;
+
+procedure Main is
+   procedure Process_Unit (Context : App_Job_Context; Unit : Analysis_Unit);
+
+   package App is new Libadalang.Helpers.App
+     (Name         => "example",
+      Description  => "Example app",
+      Process_Unit => Process_Unit);
+
+   ------------------
+   -- Process_Unit --
+   ------------------
+
+   procedure Process_Unit (Context : App_Job_Context; Unit : Analysis_Unit) is
+      pragma Unreferenced (Context);
+   begin
+      Put_Line (Unit.Root.Image);
+   end Process_Unit;
+begin
+   App.Run;
+end Main;

--- a/ada/testsuite/tests/ada_api/app/recursive/p.gpr
+++ b/ada/testsuite/tests/ada_api/app/recursive/p.gpr
@@ -1,0 +1,5 @@
+with "sub/q";
+
+project p is
+   for Source_Files use ();
+end p;

--- a/ada/testsuite/tests/ada_api/app/recursive/sub/hello.adb
+++ b/ada/testsuite/tests/ada_api/app/recursive/sub/hello.adb
@@ -1,0 +1,1 @@
+procedure hello is begin null; end;

--- a/ada/testsuite/tests/ada_api/app/recursive/sub/q.gpr
+++ b/ada/testsuite/tests/ada_api/app/recursive/sub/q.gpr
@@ -1,0 +1,2 @@
+project q is
+end q;

--- a/ada/testsuite/tests/ada_api/app/recursive/test.out
+++ b/ada/testsuite/tests/ada_api/app/recursive/test.out
@@ -1,0 +1,1 @@
+<CompilationUnit hello.adb:1:1-1:36>

--- a/ada/testsuite/tests/ada_api/app/recursive/test.yaml
+++ b/ada/testsuite/tests/ada_api/app/recursive/test.yaml
@@ -1,0 +1,3 @@
+driver: ada-api
+main: main.adb
+argv: [-Pp.gpr, -U]


### PR DESCRIPTION
When this flag is set, all sources in the project tree are processed,
rather than only the sources of the root project.

As a side effect, this behavior becomes available in the nameres program.