### PR TITLE
T831-043 Libadalang.Helpers: add support for processing runtime

### DIFF
--- a/ada/extensions/src/libadalang-helpers.ads
+++ b/ada/extensions/src/libadalang-helpers.ads
@@ -210,6 +210,11 @@ package Libadalang.Helpers is
             Help => "Process all units in the project tree, " &
               "excluding externally built projects");
 
+         package Process_Runtime is new Parse_Flag
+           (Parser, Long => "--process-runtime",
+            Help         => "Process the runtime files, and any other"
+              & " predefined sources");
+
          package Scenario_Vars is new Parse_Option_List
            (Parser, Short => "-X", Long => "--scenario-variable",
             Arg_Type      => Unbounded_String,
@@ -234,8 +239,8 @@ package Libadalang.Helpers is
             Arg_Type      => Unbounded_String,
             Default_Val   => Null_Unbounded_String,
             Help          => "Name of the configuration project file. If"
-                             & " passed, thid file must exist and neither"
-                             & " --target, nor --RTS must be passed.");
+                             & " passed, this file must exist and neither"
+                             & " --target nor --RTS must be passed.");
 
          package Auto_Dirs is new Parse_Option_List
            (Parser, "-A", "--auto-dir",

--- a/ada/testsuite/tests/ada_api/app/runtime/main.adb
+++ b/ada/testsuite/tests/ada_api/app/runtime/main.adb
@@ -1,0 +1,32 @@
+with Ada.Text_IO; use Ada.Text_IO;
+
+with Libadalang.Analysis; use Libadalang.Analysis;
+with Libadalang.Helpers;  use Libadalang.Helpers;
+
+procedure Main is
+   procedure Process_Unit (Context : App_Job_Context; Unit : Analysis_Unit);
+
+   package App is new Libadalang.Helpers.App
+     (Name         => "example",
+      Description  => "Example app",
+      Process_Unit => Process_Unit);
+
+   ------------------
+   -- Process_Unit --
+   ------------------
+
+   procedure Process_Unit (Context : App_Job_Context; Unit : Analysis_Unit) is
+      pragma Unreferenced (Context);
+      Filename    : constant String := Unit.Get_Filename;
+      Looking_For : constant String := "a-tags.ads";
+   begin
+      if Filename'Length > Looking_For'Length
+         and then Filename (Filename'Last - Looking_For'Length + 1 
+                              .. Filename'Last) = Looking_For
+      then
+         Put_Line ("Found " & Looking_For);
+      end if;
+   end Process_Unit;
+begin
+   App.Run;
+end Main;

--- a/ada/testsuite/tests/ada_api/app/runtime/p.gpr
+++ b/ada/testsuite/tests/ada_api/app/runtime/p.gpr
@@ -1,0 +1,2 @@
+project p is
+end p;

--- a/ada/testsuite/tests/ada_api/app/runtime/test.out
+++ b/ada/testsuite/tests/ada_api/app/runtime/test.out
@@ -1,0 +1,1 @@
+Found a-tags.ads

--- a/ada/testsuite/tests/ada_api/app/runtime/test.yaml
+++ b/ada/testsuite/tests/ada_api/app/runtime/test.yaml
@@ -1,0 +1,3 @@
+driver: ada-api
+main: main.adb
+argv: [-Pp.gpr, --process-runtime]


### PR DESCRIPTION
Add support for processing the runtime file through a new
  --process-runtime option.

(This also processes any "predefined sources", as there is no
distinction between those and the runtime in the current project API).