### PR TITLE
TC07-049 Fix the script to build binaries

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix: # Build debug and production
         debug: ['', 'debug']      # '' if production, 'debug' for debug
-        os: [macos-latest, ubuntu-latest, windows-latest]
+        os: [macos-10.15, ubuntu-16.04, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - run: git config --global core.autocrlf input
@@ -72,13 +72,13 @@ jobs:
         if: ${{ runner.os != 'Windows' }}
         run: utils/gh-build-binaries.sh "${{ matrix.debug }}" ${{ runner.os }}
       - name: Upload tar-ball to Bintray
-        uses: reznikmm/upload-bintray-action@v3
+        uses: reznikmm/upload-bintray-action@v4
         with:
           subject: reznikmm
           username: reznikmm
           repository: libadalang
           package: libadalang
-          version: 0.1-git
+          version: 0.2-git
           sourcePath: '*.tar.gz'
           override: 1
           apiKey: ${{secrets.BINTRAY_API_KEY}}

--- a/utils/gh-build-binaries.sh
+++ b/utils/gh-build-binaries.sh
@@ -2,27 +2,35 @@
           set -x -e
           DEBUG=$1  # Value is '' or 'debug'
           RUNNER_OS=$2  #  ${{ runner.os }} is Linux, Windiws, maxOS
-          export PROCESSORS=0
           export prefix=/tmp/ADALIB_DIR
+          if [ $RUNNER_OS = Windows ]; then
+             export prefix=/opt/ADALIB_DIR
+             mount `cmd /c cd | cut -d\: -f1`:/opt /opt
+          fi
+          export PROCESSORS=0
           export GPR_PROJECT_PATH=$prefix/share/gpr
           export CPATH=/usr/local/include:/mingw64/include
           export LIBRARY_PATH=/usr/local/lib:/mingw64/lib
           export DYLD_LIBRARY_PATH=/usr/local/lib
+          #LIBRARY_TYPES="relocatable,static"
+          LIBRARY_TYPES="static"
           pip install -r langkit/REQUIREMENTS.dev
           pip install jsonschema
           pip install langkit/
+          gprinstall --uninstall gnatcoll
+          gprinstall --uninstall gpr
 
           make -C gprbuild prefix=$prefix BUILD=${DEBUG:-production} GPRBUILD_OPTIONS="-cargs:C -Dst_mtim=st_mtimespec -gargs" libgpr.build.{shared,static} libgpr.install.{shared,static}
           BUILD=`echo $DEBUG| tr [a-z] [A-Z]`  # Convert to uppercase
-          make -C gnatcoll-core prefix=$prefix BUILD=${BUILD:-PROD} LIBRARY_TYPES="relocatable static" build install
-          python gnatcoll-bindings/iconv/setup.py build ${DEBUG:+--debug} -j0 --prefix=$prefix --library-types=relocatable,static
+          make -C gnatcoll-core prefix=$prefix BUILD=${BUILD:-PROD} LIBRARY_TYPES="${LIBRARY_TYPES/,/ }" build install
+          python gnatcoll-bindings/iconv/setup.py build ${DEBUG:+--debug} -j0 --prefix=$prefix --library-types=$LIBRARY_TYPES
           python gnatcoll-bindings/iconv/setup.py install
-          python gnatcoll-bindings/gmp/setup.py build ${DEBUG:+--debug} -j0 --prefix=$prefix --library-types=relocatable,static
+          python gnatcoll-bindings/gmp/setup.py build ${DEBUG:+--debug} -j0 --prefix=$prefix --library-types=$LIBRARY_TYPES
           python gnatcoll-bindings/gmp/setup.py install
 
           eval `langkit/manage.py setenv`
-          langkit/manage.py build-langkit-support --library-types static,relocatable
-          langkit/manage.py install-langkit-support $prefix --library-types static,relocatable
+          langkit/manage.py build-langkit-support --library-types $LIBRARY_TYPES
+          langkit/manage.py install-langkit-support $prefix --library-types $LIBRARY_TYPES
 
           BUILD=${DEBUG:+dev}  # Convert debug to dev
           # Build libadalang static library
@@ -30,17 +38,19 @@
           ./manage.py build --library-types=static --build-mode ${BUILD:-prod}
           ./manage.py install --library-types=static --build-mode ${BUILD:-prod} $prefix
           gprinstall --uninstall --prefix=$prefix mains.gpr
-          tar czf libadalang-`basename $GITHUB_REF`-$RUNNER_OS${DEBUG:+-dbg}-static.tar.gz -C $prefix .
+          tar czf libadalang-$RUNNER_OS-`basename $GITHUB_REF`${DEBUG:+-dbg}-static.tar.gz -C $prefix .
           # Build libadalang relocatable library
-          gprinstall --uninstall --prefix=$prefix libadalang.gpr
-          rm -rf build
-          # The gprbuild losts -lgmp on MacOS X, provide it in .cgpr file:
-          gprconfig --batch -o /tmp/file.cgpr --config=c --config=ada
-          if [ $RUNNER_OS = macOS ]; then
-            sed -i -e '/for Shared_Library_Minimum_Switches use/s/$/ ("-lgmp") \&/' /tmp/file.cgpr
-            cat /tmp/file.cgpr
+          if [ "$LIBRARY_TYPES" != static ]; then
+            gprinstall --uninstall --prefix=$prefix libadalang.gpr
+            rm -rf build
+            # The gprbuild losts -lgmp on MacOS X, provide it in .cgpr file:
+            gprconfig --batch -o /tmp/file.cgpr --config=c --config=ada
+            if [ $RUNNER_OS = macOS ]; then
+              sed -i -e '/for Shared_Library_Minimum_Switches use/s/use/use ("-lgmp") \&/' /tmp/file.cgpr
+              cat /tmp/file.cgpr
+            fi
+            ./manage.py generate
+            ./manage.py build --library-types=relocatable --build-mode ${BUILD:-prod} --gargs=--config=/tmp/file.cgpr
+            ./manage.py install --library-types=relocatable --build-mode ${BUILD:-prod} $prefix
+            tar czf libadalang-$RUNNER_OS-`basename $GITHUB_REF`${DEBUG:+-dbg}.tar.gz -C $prefix .
           fi
-          ./manage.py generate
-          ./manage.py build --library-types=relocatable --build-mode ${BUILD:-prod} --gargs=--config=/tmp/file.cgpr
-          ./manage.py install --library-types=relocatable --build-mode ${BUILD:-prod} $prefix
-          tar czf libadalang-`basename $GITHUB_REF`-$RUNNER_OS${DEBUG:+-dbg}.tar.gz -C $prefix .


### PR DESCRIPTION
* Uninstall gnatcoll and gpr from gnat CE 2020 to avoid conflicts
* Mount /opt dir on windows and use it for ADALIB_DIR. This way
  msys2 and native path to this directory match.
* Don't build relocatable libraries, because they crash builds TC11_054
* Use oldes version of Mac OS and Ubuntu to keep compatibility with
  older system
* Upload to newer version on BinTray, because older one has locked.
  Also change archive file names to avoid conflicts with locked
  files.
* Upgrade to upload-bintray-action@v4. It will auto-create a version
  before uploading.