### PR TITLE
U601-009: Fix erroneous filtering of generic actuals.

### DIFF
--- a/ada/ast.py
+++ b/ada/ast.py
@@ -781,7 +781,7 @@ class AdaNode(ASTNode):
             # but we should handle objects too.
             lambda n=T.Name.entity: n.name_designated_type.cast(T.entity)._or(
                 # If we don't find a type, find something else
-                env.bind(n.children_env, n.env_elements.at(0))
+                n.all_env_elements.at(0)
             ),
 
             lambda _: No(T.entity),

--- a/testsuite/tests/navigation/resolve_generic_subp/test.adb
+++ b/testsuite/tests/navigation/resolve_generic_subp/test.adb
@@ -1,0 +1,35 @@
+procedure Test is
+   generic
+      type T is private;
+   package Pkg is
+      procedure Bar;
+   end Pkg;
+
+   generic
+      with procedure Foo (X : Integer);
+   package Internal is
+      procedure Bar;
+   end Internal;
+
+   procedure Act (X : Integer) is null;
+
+   package body pkg is
+      package Internal_Pkg is new Internal (Foo => Act);
+
+      procedure Bar is
+      begin
+         Internal_Pkg.Bar;
+      end Bar;
+   end Pkg;
+
+   package body Internal is
+      procedure Bar is
+      begin
+         Foo (12);
+      end Bar;
+   end Internal;
+
+   package My_Pkg is new Pkg (Integer);
+begin
+   My_Pkg.Bar;
+end Test;

--- a/testsuite/tests/navigation/resolve_generic_subp/test.out
+++ b/testsuite/tests/navigation/resolve_generic_subp/test.out
@@ -1,0 +1,5 @@
+In call My_Pkg.Bar;
+In call Internal_Pkg.Bar
+In call Foo (12)
+The actual for generic subprogram Foo resolves to:
+<NullSubpDecl ["Act"] test.adb:14:4-14:40>

--- a/testsuite/tests/navigation/resolve_generic_subp/test.py
+++ b/testsuite/tests/navigation/resolve_generic_subp/test.py
@@ -1,0 +1,17 @@
+import libadalang as lal
+
+ctx = lal.AnalysisContext()
+u = ctx.get_from_file("test.adb")
+call = u.root.findall(lal.CallStmt)[-1]
+print("In call " + call.text)
+subp = call.f_call.p_referenced_decl()
+body = subp.p_body_part()
+call = body.find(lal.CallStmt).f_call
+print("In call " + call.text)
+subp = call.p_referenced_decl()
+body = subp.p_body_part()
+call = body.find(lal.CallStmt).f_call
+print("In call " + call.text)
+print("The actual for generic subprogram Foo resolves to:")
+print(call.p_referenced_decl())
+

--- a/testsuite/tests/navigation/resolve_generic_subp/test.yaml
+++ b/testsuite/tests/navigation/resolve_generic_subp/test.yaml
@@ -1,0 +1,2 @@
+driver: python
+input_sources: [test.adb]

--- a/user_manual/changes/U601-009.yaml
+++ b/user_manual/changes/U601-009.yaml
@@ -1,0 +1,6 @@
+type: bugfix
+title: Fix resolution of generic subprogram actuals
+description: |
+    This change fixes a bug where resolving a generic subprogram reference
+    when inside a generic context could trigger a ``Property_Error``.
+date: 2021-06-16


### PR DESCRIPTION
The previous implementation of resolve_generic_actual was using env_elements
when resolving a subprogram actual, but env_elements_baseid performs filtering
as if the subprogram was used in a call, and thus would exclude all non-paramless
subprograms. We now use all_env_elements instead.