### PR TITLE
U712-008: fix forgotten case

### DIFF
--- a/ada/ast.py
+++ b/ada/ast.py
@@ -811,7 +811,9 @@ class AdaNode(ASTNode):
             ).as_bare_entity.cast(BaseSubpBody).then(
                 lambda b: If(
                     b.is_library_item,
-                    b.defining_name.referenced_unit(UnitSpecification).then(
+                    b.defining_name.referenced_unit(
+                        UnitSpecification, not_found_is_error=False
+                    ).then(
                         lambda u: u.root._.has_with_visibility(refd_unit)
                     ),
                     False

--- a/testsuite/tests/name_resolution/non_visible_dependency/foo.ads
+++ b/testsuite/tests/name_resolution/non_visible_dependency/foo.ads
@@ -1,0 +1,3 @@
+package Foo is
+   procedure Bar is null;
+end Foo;

--- a/testsuite/tests/name_resolution/non_visible_dependency/test.adb
+++ b/testsuite/tests/name_resolution/non_visible_dependency/test.adb
@@ -1,0 +1,5 @@
+procedure Test is
+begin
+   Foo.Bar;
+   pragma Test_Statement;
+end Test;

--- a/testsuite/tests/name_resolution/non_visible_dependency/test.out
+++ b/testsuite/tests/name_resolution/non_visible_dependency/test.out
@@ -1,0 +1,13 @@
+Analyzing foo.ads
+#################
+
+Analyzing test.adb
+##################
+
+Resolving xrefs for node <CallStmt test.adb:3:4-3:12>
+*****************************************************
+
+Resolution failed for node <CallStmt test.adb:3:4-3:12>
+
+
+Done.

--- a/testsuite/tests/name_resolution/non_visible_dependency/test.yaml
+++ b/testsuite/tests/name_resolution/non_visible_dependency/test.yaml
@@ -1,0 +1,11 @@
+# Test that name resolution behaves as expected in the case of a non visible
+# dependency in a library level subprogram body.
+#
+# This test was added because of a bug in the unit_requested callback mechanism
+# (a warning would be emitted when LAL was looking for a non visible dependency
+# through the spec of a library level subprogram body), but is generally useful
+# to exert the code path where we look for withed units through the spec of a
+# library level subprogram body.
+
+driver: name-resolution
+input_sources: [foo.ads, test.adb]


### PR DESCRIPTION
Where we did treat missing the spec of a library level subp body as an
error/missing dependency.