### PR TITLE
U727-022: Fix parsing bug in `Abstract_State`

### DIFF
--- a/ada/grammar.py
+++ b/ada/grammar.py
@@ -546,7 +546,8 @@ A.add_rules(
     aspect_assoc=Or(
         AspectAssoc(
             Identifier(L.Identifier(match_text="Abstract_State")),
-            Opt("=>", AbstractStateDeclExpr(A.multi_abstract_state_decl))
+            Opt("=>", Or(A.null_literal,
+                         AbstractStateDeclExpr(A.multi_abstract_state_decl)))
         ),
         AspectAssoc(A.name, Opt("=>", Or(A.expr, A.contract_cases_expr)))
     ),

--- a/testsuite/tests/parser/null_abstract_state/input
+++ b/testsuite/tests/parser/null_abstract_state/input
@@ -1,0 +1,1 @@
+Abstract_State => null

--- a/testsuite/tests/parser/null_abstract_state/test.out
+++ b/testsuite/tests/parser/null_abstract_state/test.out
@@ -1,0 +1,5 @@
+AspectAssoc[1:1-1:23]
+|f_id:
+|  Id[1:1-1:15]: Abstract_State
+|f_expr:
+|  Null[1:19-1:23]: null

--- a/testsuite/tests/parser/null_abstract_state/test.yaml
+++ b/testsuite/tests/parser/null_abstract_state/test.yaml
@@ -1,0 +1,2 @@
+driver: parser
+rule: aspect_assoc


### PR DESCRIPTION
`null` is a valid abstract state value