### PR TITLE
U526-014: Get rid of IndexConstraint & DiscriminantConstraint

### DIFF
--- a/ada/ast.py
+++ b/ada/ast.py
@@ -3892,7 +3892,7 @@ class ComponentList(BaseFormalParamHolder):
                         pcl.type_decl.discriminants_list,
                         Entity.type_def.cast(DerivedTypeDef)
                         .subtype_indication.constraint
-                        .cast(DiscriminantConstraint)._.constraints,
+                        .cast(CompositeConstraint)._.constraints,
                         is_dottable_subp=False
                     ),
                     include_discriminants=False
@@ -5776,14 +5776,19 @@ class Constraint(AdaNode):
     def is_static():
         return Entity.match(
             lambda rc=RangeConstraint: rc.range.range.is_static_expr,
-            lambda ic=IndexConstraint:
-            ic.constraints.all(lambda c: c.match(
-                lambda st=SubtypeIndication: st.is_static_subtype,
-                lambda e=Expr: e.is_static_expr,
-                lambda _: False
-            )),
-            lambda dc=DiscriminantConstraint: dc.constraints.all(
-                lambda c: c.expr.is_static_expr
+            lambda cc=CompositeConstraint: If(
+                cc.is_index_constraint,
+                cc.constraints.all(
+                    lambda c: c.cast(CompositeConstraintAssoc).constraint_expr
+                    .match(
+                        lambda st=SubtypeIndication: st.is_static_subtype,
+                        lambda e=Expr: e.is_static_expr,
+                        lambda _: False
+                    )
+                ),
+                cc.constraints.all(
+                    lambda c: c.expr.is_static_expr
+                )
             ),
             # TODO: Handle constraints for floating point types
             lambda _: False
@@ -5828,61 +5833,63 @@ class DeltaConstraint(Constraint):
     )
 
 
-class IndexConstraint(Constraint):
+class CompositeConstraint(Constraint):
     """
-    List of type constraints.
+    Constraint for a composite type. Due to ambiguities in the Ada grammar,
+    this could be either a list of index constraints, if the owning type is an
+    array type, or a list of discriminant constraints, if the owning type is a
+    discriminated record type.
     """
-    constraints = Field(type=T.ConstraintList)
 
-    @langkit_property()
-    def xref_equation():
-        typ = Var(Entity.subtype)
-        return Entity.constraints.logic_all(
-            lambda i, c:
-            # If the index constraint is an expression (which means it is
-            # either a BinOp (first .. last) or an AttributeRef (X'Range)),
-            # we assign to the type of that expression the type of the index
-            # which we are constraining, or else it would be resolved without
-            # any context and we could get erroneous types in some cases.
-            # Consider for example ``subtype T is List ('A' .. 'B')``: here,
-            # 'A' and 'B' could type to e.g. ``Character`` although the index
-            # type of ``List`` is for example ``My_Character``. But if we bind
-            # the type of ``'A' .. 'B'`` to ``My_Character`` as we now do,
-            # the type will be propagated to both 'A' and 'B' and therefore
-            # they will get the correct types.
-
-            # Note that it's currently necessary to first assign the expected
-            # type to the range before recursively constructing its xref
-            # equations, as we have cases (e.g. BinOp) where resolution takes
-            # different paths depending on its operands' types (e.g. whether
-            # it's a universal type or not).
-            # todo: rework this once expected types are available (T218-019).
-            c.cast(T.Expr).then(
-                lambda e: Self.type_bind_val(e.type_var, typ.index_type(i)),
-                default_val=LogicTrue()
-            ) & c.xref_equation
-        )
-
-
-class DiscriminantConstraint(Constraint):
-    """
-    List of constraints that relate to type discriminants.
-    """
     constraints = Field(type=T.AssocList)
 
+    @langkit_property(public=True)
+    def is_index_constraint():
+        """
+        Whether this composite constraint is an index constraint.
+        """
+        return Entity.subtype.is_array_type
+
+    @langkit_property(public=True)
+    def is_discriminant_constraint():
+        """
+        Whether this composite constraint is a discriminant constraint.
+        """
+        return Not(Entity.is_index_constraint)
+
     @langkit_property()
     def xref_equation():
         typ = Var(Entity.subtype)
-
         return If(
-            # Due to ambiguities in the grammar, this can actually be parsed as
-            # a DiscriminantConstraint but be an index constraint.
-            typ.is_array,
+            Entity.is_index_constraint,
+            Entity.constraints.logic_all(lambda i, c: Let(
+                lambda ex=c.cast(T.CompositeConstraintAssoc).constraint_expr:
+                # If the index constraint is an expression (which means it
+                # is either a BinOp (first .. last) or an AttributeRef
+                # (X'Range)), we assign to the type of that expression the
+                # type of the index which we are constraining, or else it
+                # would be resolved without any context and we could get
+                # erroneous types in some cases.  Consider for example
+                # ``subtype T is List ('A' .. 'B')``: here, 'A' and 'B'
+                # could type to e.g. ``Character`` although the index type
+                # of ``List`` is for example ``My_Character``. But if we
+                # bind the type of ``'A' .. 'B'`` to ``My_Character`` as we
+                # now do, the type will be propagated to both 'A' and 'B'
+                # and therefore they will get the correct types.
 
-            # Index constraints imply no overloading
-            Entity.constraints.logic_all(
-                lambda c: c.expr.sub_equation
-            ),
+                # Note that it's currently necessary to first assign the
+                # expected type to the range before recursively
+                # constructing its xref equations, as we have cases (e.g.
+                # BinOp) where resolution takes different paths depending
+                # on its operands' types (e.g. whether it's a universal
+                # type or not).  todo: rework this once expected types are
+                # available (T218-019).
+                ex.cast(T.Expr).then(
+                    lambda e:
+                    Self.type_bind_val(e.type_var, typ.index_type(i)),
+                    default_val=LogicTrue()
+                ) & ex.sub_equation
+            )),
 
             # Regular discriminant constraint case
             Self.match_formals(
@@ -5926,14 +5933,14 @@ class BasicAssoc(AdaNode):
         )
 
 
-class DiscriminantAssoc(BasicAssoc):
+class CompositeConstraintAssoc(BasicAssoc):
     """
     Association of discriminant names to an expression.
     """
     ids = Field(type=T.DiscriminantChoiceList)
-    discr_expr = Field(type=T.Expr)
+    constraint_expr = Field(type=T.AdaNode)
 
-    expr = Property(Entity.discr_expr)
+    expr = Property(Entity.constraint_expr.cast_or_raise(T.Expr))
     names = Property(Self.ids.map(lambda i: i.cast(T.AdaNode)))
 
 
@@ -11616,7 +11623,7 @@ class AssocList(BasicAssoc.list):
             i.generic_entity_name.referenced_decl.cast(T.GenericDecl)
             ._.formal_part.abstract_formal_params,
 
-            lambda c=T.DiscriminantConstraint:
+            lambda c=T.CompositeConstraint:
             c.subtype._.discriminants_list,
 
             lambda a=T.BaseAggregate: origin.bind(Self, env.bind(

--- a/testsuite/tests/lexical_envs/records/test.out
+++ b/testsuite/tests/lexical_envs/records/test.out
@@ -160,16 +160,20 @@ CompilationUnit[1:1-11:9]
 |  |  |  |  |  |  |  |  |  |  |  |  |f_name:
 |  |  |  |  |  |  |  |  |  |  |  |  |  Id[9:11-9:17]: String
 |  |  |  |  |  |  |  |  |  |  |  |  |f_constraint:
-|  |  |  |  |  |  |  |  |  |  |  |  |  IndexConstraint[9:18-9:26]
+|  |  |  |  |  |  |  |  |  |  |  |  |  CompositeConstraint[9:18-9:26]
 |  |  |  |  |  |  |  |  |  |  |  |  |  |f_constraints:
-|  |  |  |  |  |  |  |  |  |  |  |  |  |  ConstraintList[9:19-9:25]
-|  |  |  |  |  |  |  |  |  |  |  |  |  |  |  BinOp[9:19-9:25]
-|  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |f_left:
-|  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  Int[9:19-9:20]: 1
-|  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |f_op:
-|  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  OpDoubleDot[9:21-9:23]
-|  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |f_right:
-|  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  Id[9:24-9:25]: N
+|  |  |  |  |  |  |  |  |  |  |  |  |  |  AssocList[9:19-9:25]
+|  |  |  |  |  |  |  |  |  |  |  |  |  |  |  CompositeConstraintAssoc[9:19-9:25]
+|  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |f_ids:
+|  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  DiscriminantChoiceList[9:17-9:17]: <empty list>
+|  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |f_constraint_expr:
+|  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  BinOp[9:19-9:25]
+|  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |f_left:
+|  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  Int[9:19-9:20]: 1
+|  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |f_op:
+|  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  OpDoubleDot[9:21-9:23]
+|  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |f_right:
+|  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  Id[9:24-9:25]: N
 |  |  |  |  |  |  |  |  |  |  |f_default_expr: <null>
 |  |  |  |  |  |  |  |  |  |  |f_aspects: <null>
 |  |  |  |  |  |  |  |  |f_variant_part: <null>

--- a/testsuite/tests/parser/full_type_decl_17/test.out
+++ b/testsuite/tests/parser/full_type_decl_17/test.out
@@ -16,16 +16,20 @@ TypeDecl[1:1-1:51]
 |  |  |  |  |f_name:
 |  |  |  |  |  Id[1:20-1:27]: Integer
 |  |  |  |  |f_constraint:
-|  |  |  |  |  IndexConstraint[1:28-1:38]
+|  |  |  |  |  CompositeConstraint[1:28-1:38]
 |  |  |  |  |  |f_constraints:
-|  |  |  |  |  |  ConstraintList[1:29-1:37]
-|  |  |  |  |  |  |  BinOp[1:29-1:37]
-|  |  |  |  |  |  |  |f_left:
-|  |  |  |  |  |  |  |  Int[1:29-1:31]: 12
-|  |  |  |  |  |  |  |f_op:
-|  |  |  |  |  |  |  |  OpDoubleDot[1:32-1:34]
-|  |  |  |  |  |  |  |f_right:
-|  |  |  |  |  |  |  |  Int[1:35-1:37]: 15
+|  |  |  |  |  |  AssocList[1:29-1:37]
+|  |  |  |  |  |  |  CompositeConstraintAssoc[1:29-1:37]
+|  |  |  |  |  |  |  |f_ids:
+|  |  |  |  |  |  |  |  DiscriminantChoiceList[1:27-1:27]: <empty list>
+|  |  |  |  |  |  |  |f_constraint_expr:
+|  |  |  |  |  |  |  |  BinOp[1:29-1:37]
+|  |  |  |  |  |  |  |  |f_left:
+|  |  |  |  |  |  |  |  |  Int[1:29-1:31]: 12
+|  |  |  |  |  |  |  |  |f_op:
+|  |  |  |  |  |  |  |  |  OpDoubleDot[1:32-1:34]
+|  |  |  |  |  |  |  |  |f_right:
+|  |  |  |  |  |  |  |  |  Int[1:35-1:37]: 15
 |  |f_component_type:
 |  |  ComponentDef[1:43-1:50]
 |  |  |f_has_aliased:

--- a/testsuite/tests/parser/full_type_decl_8/test.out
+++ b/testsuite/tests/parser/full_type_decl_8/test.out
@@ -19,15 +19,15 @@ TypeDecl[1:1-1:79]
 |  |  |f_name:
 |  |  |  Id[1:15-1:16]: A
 |  |  |f_constraint:
-|  |  |  DiscriminantConstraint[1:17-1:42]
+|  |  |  CompositeConstraint[1:17-1:42]
 |  |  |  |f_constraints:
 |  |  |  |  AssocList[1:18-1:41]
-|  |  |  |  |  DiscriminantAssoc[1:18-1:41]
+|  |  |  |  |  CompositeConstraintAssoc[1:18-1:41]
 |  |  |  |  |  |f_ids:
 |  |  |  |  |  |  DiscriminantChoiceList[1:18-1:35]
 |  |  |  |  |  |  |  Id[1:18-1:25]: Discr_1
 |  |  |  |  |  |  |  Id[1:28-1:35]: Discr_2
-|  |  |  |  |  |f_discr_expr:
+|  |  |  |  |  |f_constraint_expr:
 |  |  |  |  |  |  Int[1:39-1:41]: 12
 |  |f_interfaces:
 |  |  ParentList[1:41-1:41]: <empty list>

--- a/testsuite/tests/parser/subprogram_spec_4/test.out
+++ b/testsuite/tests/parser/subprogram_spec_4/test.out
@@ -17,13 +17,17 @@ SubpSpec[1:1-1:37]
 |  |  |f_suffix:
 |  |  |  Id[1:23-1:26]: Arr
 |  |f_constraint:
-|  |  IndexConstraint[1:27-1:37]
+|  |  CompositeConstraint[1:27-1:37]
 |  |  |f_constraints:
-|  |  |  ConstraintList[1:28-1:36]
-|  |  |  |  BinOp[1:28-1:36]
-|  |  |  |  |f_left:
-|  |  |  |  |  Int[1:28-1:30]: 12
-|  |  |  |  |f_op:
-|  |  |  |  |  OpDoubleDot[1:31-1:33]
-|  |  |  |  |f_right:
-|  |  |  |  |  Int[1:34-1:36]: 18
+|  |  |  AssocList[1:28-1:36]
+|  |  |  |  CompositeConstraintAssoc[1:28-1:36]
+|  |  |  |  |f_ids:
+|  |  |  |  |  DiscriminantChoiceList[1:26-1:26]: <empty list>
+|  |  |  |  |f_constraint_expr:
+|  |  |  |  |  BinOp[1:28-1:36]
+|  |  |  |  |  |f_left:
+|  |  |  |  |  |  Int[1:28-1:30]: 12
+|  |  |  |  |  |f_op:
+|  |  |  |  |  |  OpDoubleDot[1:31-1:33]
+|  |  |  |  |  |f_right:
+|  |  |  |  |  |  Int[1:34-1:36]: 18

--- a/testsuite/tests/parser/subtype_decl_0/test.out
+++ b/testsuite/tests/parser/subtype_decl_0/test.out
@@ -10,14 +10,18 @@ SubtypeDecl[1:1-1:26]
 |  |f_name:
 |  |  Id[1:14-1:15]: B
 |  |f_constraint:
-|  |  IndexConstraint[1:16-1:25]
+|  |  CompositeConstraint[1:16-1:25]
 |  |  |f_constraints:
-|  |  |  ConstraintList[1:17-1:24]
-|  |  |  |  BinOp[1:17-1:24]
-|  |  |  |  |f_left:
-|  |  |  |  |  Int[1:17-1:18]: 1
-|  |  |  |  |f_op:
-|  |  |  |  |  OpDoubleDot[1:19-1:21]
-|  |  |  |  |f_right:
-|  |  |  |  |  Int[1:22-1:24]: 12
+|  |  |  AssocList[1:17-1:24]
+|  |  |  |  CompositeConstraintAssoc[1:17-1:24]
+|  |  |  |  |f_ids:
+|  |  |  |  |  DiscriminantChoiceList[1:15-1:15]: <empty list>
+|  |  |  |  |f_constraint_expr:
+|  |  |  |  |  BinOp[1:17-1:24]
+|  |  |  |  |  |f_left:
+|  |  |  |  |  |  Int[1:17-1:18]: 1
+|  |  |  |  |  |f_op:
+|  |  |  |  |  |  OpDoubleDot[1:19-1:21]
+|  |  |  |  |  |f_right:
+|  |  |  |  |  |  Int[1:22-1:24]: 12
 |f_aspects: <null>

--- a/testsuite/tests/properties/expr_eval/with_rebindings_2/test.py
+++ b/testsuite/tests/properties/expr_eval/with_rebindings_2/test.py
@@ -8,7 +8,7 @@ V_decl = u.root.findall(lal.ObjectDecl)[1]
 R_Arr_ref = V_decl.f_type_expr
 R_Arr_decl = R_Arr_ref.p_designated_type_decl
 R_ref = (R_Arr_decl.f_type_def.f_subtype_indication
-         .f_constraint.f_constraints[0].f_discr_expr)
+         .f_constraint.f_constraints[0].f_constraint_expr)
 R_decl = R_ref.p_referenced_decl()
 R_range = R_decl.p_discrete_range
 

--- a/user_manual/changes/U526-014.yaml
+++ b/user_manual/changes/U526-014.yaml
@@ -1,0 +1,29 @@
+type: api-change
+title: Get rid of discriminant/index constraints
+
+description: |
+    ``DiscriminantConstraint`` and ``IndexConstraint`` nodes are now replaced
+    by a single node type, ``CompositeConstraint``.
+
+    This fixes a problem where, due to an ambiguity in the Ada grammar, we
+    would incorrectly parse index constraints as being discriminant
+    constraints.
+
+    To know whether a ``CompositeConstraint`` is an index or a discriminant
+    constraint, two new properties, ``p_is_index_constraint`` and
+    ``p_is_discriminant_constraint`` have been exposed.
+
+    A new assoc node type, ``CompositeConstraintAssoc``, is introduced. It can
+    store a discriminant constraint assoc, as well as an index constraint.
+
+    The consequence is that a ``CompositeConstraintAssoc`` can store a construct
+    that is illegal Ada, such as in the code:
+
+    .. code:: ada
+
+        A : My_Type (Disc => 12 .. 15)
+
+    This currently won't be caught by LAL, and is in-line with other such
+    decisions where we parse a superset of Ada syntax.
+
+date: 2021-08-06


### PR DESCRIPTION
Replace them by a single CompositeConstraint, with p_is_index_constraint
and p_is_discriminant_constraint properties.

This avoids the wrong parsing of some index constraints as discriminant
constraints.

On the other hand, it means that Libadalang will happily parse wrong
code such as:

    A : My_Type (Disc => 12 .. 15);

In line with other such decisions we make about parsing a superset of
what is correct Ada.