### PR TITLE
U913-015: Fix lookup scope for pragma resolution.

### DIFF
--- a/testsuite/tests/properties/get_pragma_component/test.adb
+++ b/testsuite/tests/properties/get_pragma_component/test.adb
@@ -1,0 +1,10 @@
+procedure Test is
+   type T is record
+      X : Integer;
+      --% node.p_get_pragma("atomic")
+      pragma Atomic (X);
+      --% node.p_associated_decls
+   end record;
+begin
+   null;
+end Test;

--- a/testsuite/tests/properties/get_pragma_component/test.out
+++ b/testsuite/tests/properties/get_pragma_component/test.out
@@ -1,0 +1,7 @@
+Eval 'node.p_get_pragma("atomic")' on node <ComponentDecl ["X"] test.adb:3:7-3:19>
+Result: <PragmaNode test.adb:5:7-5:25>
+
+Eval 'node.p_associated_decls' on node <PragmaNode test.adb:5:7-5:25>
+Result: [<ComponentDecl ["X"] test.adb:3:7-3:19>]
+
+

--- a/testsuite/tests/properties/get_pragma_component/test.yaml
+++ b/testsuite/tests/properties/get_pragma_component/test.yaml
@@ -1,0 +1,2 @@
+driver: inline-playground
+input_sources: [test.adb]


### PR DESCRIPTION
We were wrongly assuming that a pragma would always apply to a `BasicDecl` lying
in a `DeclarativePart`, which is not necessarily the case, for example with
`ComponentDecl`s (components of a record).