### PR TITLE
U219-050 fix more memory corruption problems with UnitProvider binding

### DIFF
--- a/extensions/ocaml_api/unit_providers/module_struct
+++ b/extensions/ocaml_api/unit_providers/module_struct
@@ -22,8 +22,16 @@
     (fun v ->
       f (!@ v))
 
-  let wrap v =
-    allocate ~finalise:dec_ref (ptr void) v
+  (* Keep is a special argument designed to extend the lifetime of an OCaml
+     value. We put in a ref which is set to [None] only in the finalization
+     function. This guarantees it won't be collected before. *)
+  let wrap ?keep v =
+    let ref_keep = ref keep in
+    let finalise arg =
+      ref_keep := None;
+      dec_ref arg
+    in
+    allocate ~finalise (ptr void) v
 
   let for_project
       ?(project = "")
@@ -71,4 +79,8 @@
     let array = CArray.of_list (ptr char) cstrings_null in
     let ptr = CArray.start array in
     let result = create_auto_provider ptr "" in
-    wrap result
+    (* Extend the lifetime of cstrings here, to make sure it is not garbage
+       collected while [create_auto_provided] executes, nor after. (It is not
+       clear whether LAL keeps internal references to this C object after the
+       call to create_auto_provider, but simpler fixes do not work anyway. *)
+    wrap ~keep:cstrings result


### PR DESCRIPTION
Based on what we found in Ctypes discussions [1, 2, 3], and what we
observed in practice using Valgrind, the OCaml lifetime for the C
strings containing the names of the files in the project for an auto
provider is too short. The garbage collector can collect those strings
before the function create_auto_provider has fully ran.

We correct this by forcing the cstrings local variable to be live accross
the entire call, and even further: it won't be collected until the
finalizer for the the UnitProvider runs. In practice, this eliminates
all the problems we've been able to see with Valgrind.

[1] https://github.com/ocamllabs/ocaml-ctypes/issues/476
[2] https://github.com/ocamllabs/ocaml-ctypes/issues/571
[3] http://lists.ocaml.org/pipermail/ctypes/2018-March/000276.html