### PR TITLE
Swith CI to use ubuntu-18.04

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix: # Build debug and production
         debug: ['', 'debug']      # '' if production, 'debug' for debug
-        os: [macos-10.15, ubuntu-16.04, windows-latest]
+        os: [macos-10.15, ubuntu-18.04, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - run: git config --global core.autocrlf input


### PR DESCRIPTION
GitHub doesn't provide ubuntu-16.04 "runner" any more. Let's
switch to oldest available (ubuntu-18.04).