### PR TITLE
U918-003: Fix name resolution of implicit `/=` operator.

### DIFF
--- a/testsuite/tests/name_resolution/synthetic_neq/test.adb
+++ b/testsuite/tests/name_resolution/synthetic_neq/test.adb
@@ -13,4 +13,9 @@ begin
       raise Program_Error;
    end if;
    pragma Test_Statement;
+
+   if "/=" (A, B) then
+      raise Program_Error;
+   end if;
+   pragma Test_Statement;
 end Main;

--- a/testsuite/tests/name_resolution/synthetic_neq/test.out
+++ b/testsuite/tests/name_resolution/synthetic_neq/test.out
@@ -16,5 +16,21 @@ Expr: <Id "B" test.adb:12:12-12:13>
   references: <DefiningName test.adb:10:7-10:8>
   type:       <TypeDecl ["T"] test.adb:3:7-3:29>
 
+Resolving xrefs for node <IfStmt test.adb:17:4-19:11>
+*****************************************************
+
+Expr: <CallExpr test.adb:17:7-17:18>
+  references: <DefiningName test.adb:5:16-5:19>
+  type:       <TypeDecl ["Boolean"] __standard:3:3-3:33>
+Expr: <Str ""/="" test.adb:17:7-17:11>
+  references: <DefiningName test.adb:5:16-5:19>
+  type:       <TypeDecl ["Boolean"] __standard:3:3-3:33>
+Expr: <Id "A" test.adb:17:13-17:14>
+  references: <DefiningName test.adb:10:4-10:5>
+  type:       <TypeDecl ["T"] test.adb:3:7-3:29>
+Expr: <Id "B" test.adb:17:16-17:17>
+  references: <DefiningName test.adb:10:7-10:8>
+  type:       <TypeDecl ["T"] test.adb:3:7-3:29>
+
 
 Done.


### PR DESCRIPTION
This is done by reworking how implicit `/=` operators are handled. In particular,
we remove the special casing done it operator name resolution and instead rely and
lexical environments only, by adding an entry for the `/=` operator whenever we
have to add an entry for a user-defined `=` operator.

This is therefore a nice cleanup.