### PR TITLE
TB01-005: Name resolution of `limited with` clauses.

### DIFF
--- a/testsuite/tests/name_resolution/limited_with_child_pkg/p-a.ads
+++ b/testsuite/tests/name_resolution/limited_with_child_pkg/p-a.ads
@@ -1,4 +1,5 @@
 limited with P.A.B;
+pragma Test_Statement;
 
 package P.A is
    type T is tagged null record;

--- a/testsuite/tests/name_resolution/limited_with_child_pkg/test.out
+++ b/testsuite/tests/name_resolution/limited_with_child_pkg/test.out
@@ -1,6 +1,26 @@
 Analyzing p-a.ads
 #################
 
+Resolving xrefs for node <WithClause p-a.ads:1:1-1:20>
+******************************************************
+
+Expr: <DottedName p-a.ads:1:14-1:19>
+  references: <DefiningName p-a-b.ads:1:9-1:14>
+  type:       None
+Expr: <DottedName p-a.ads:1:14-1:17>
+  references: <DefiningName p-a.ads:4:9-4:12>
+  type:       None
+Expr: <Id "P" p-a.ads:1:14-1:15>
+  references: <DefiningName p.ads:1:9-1:10>
+  type:       None
+Expr: <Id "A" p-a.ads:1:16-1:17>
+  references: <DefiningName p-a.ads:4:9-4:12>
+  type:       None
+Expr: <Id "B" p-a.ads:1:18-1:19>
+  references: <DefiningName p-a-b.ads:1:9-1:14>
+  type:       None
+
+
 Analyzing p-a-b.ads
 ###################
 
@@ -8,13 +28,13 @@ Resolving xrefs for node <DefiningName p-a-b.ads:1:9-1:14>
 **********************************************************
 
 Expr: <DottedName p-a-b.ads:1:9-1:12>
-  references: <DefiningName p-a.ads:3:9-3:12>
+  references: <DefiningName p-a.ads:4:9-4:12>
   type:       None
 Expr: <Id "P" p-a-b.ads:1:9-1:10>
   references: <DefiningName p.ads:1:9-1:10>
   type:       None
 Expr: <Id "A" p-a-b.ads:1:11-1:12>
-  references: <DefiningName p-a.ads:3:9-3:12>
+  references: <DefiningName p-a.ads:4:9-4:12>
   type:       None
 
 Resolving xrefs for node <SubpSpec p-a-b.ads:2:4-2:38>
@@ -25,10 +45,10 @@ Resolving xrefs for node <ParamSpec ["X"] p-a-b.ads:2:19-2:37>
 **************************************************************
 
 Expr: <AttributeRef p-a-b.ads:2:30-2:37>
-  references: <DefiningName p-a.ads:4:9-4:10>
+  references: <DefiningName p-a.ads:5:9-5:10>
   type:       None
 Expr: <Id "T" p-a-b.ads:2:30-2:31>
-  references: <DefiningName p-a.ads:4:9-4:10>
+  references: <DefiningName p-a.ads:5:9-5:10>
   type:       None
 Expr: <Id "Class" p-a-b.ads:2:32-2:37>
   references: None
@@ -44,13 +64,13 @@ Expr: <DottedName p-a-b.ads:3:5-3:10>
   references: <DefiningName p-a-b.ads:1:9-1:14>
   type:       None
 Expr: <DottedName p-a-b.ads:3:5-3:8>
-  references: <DefiningName p-a.ads:3:9-3:12>
+  references: <DefiningName p-a.ads:4:9-4:12>
   type:       None
 Expr: <Id "P" p-a-b.ads:3:5-3:6>
   references: <DefiningName p.ads:1:9-1:10>
   type:       None
 Expr: <Id "A" p-a-b.ads:3:7-3:8>
-  references: <DefiningName p-a.ads:3:9-3:12>
+  references: <DefiningName p-a.ads:4:9-4:12>
   type:       None
 Expr: <Id "B" p-a-b.ads:3:9-3:10>
   references: <DefiningName p-a-b.ads:1:9-1:14>

--- a/user_manual/changes/TB01-005.yaml
+++ b/user_manual/changes/TB01-005.yaml
@@ -1,0 +1,8 @@
+type: bugfix
+title: Name resolution of ``limited with`` clauses
+description: |
+    This change fixes a bug where calling ``P_Referenced_Decl`` on any part
+    of a limited with clause importing a child unit of the current unit would
+    yield ``None``. The declaration inside the designated CompilationUnit is
+    now correctly returned.
+date: 2021-10-14


### PR DESCRIPTION
The previous implementation failed to resolve names in a limited with clause
designating a child unit of the current unit, because the behavior of
`xref_no_overloading` takes into account visibility as seen from node at
the origin of the query: since a with clause appears before the declaration
of the current unit, an env query of any name referencing that unit or one of
its children would return an empty result.