### PR TITLE
UA25-009: Fix regression on invalid code.

### DIFF
--- a/testsuite/tests/name_resolution/invalid_UA25-009/test.adb
+++ b/testsuite/tests/name_resolution/invalid_UA25-009/test.adb
@@ -1,0 +1,7 @@
+procedure Test is
+   type T is tagged null record;
+
+   procedure Foo (T : T'Class) is null;
+   pragma Test_Block;
+begin
+end Test;

--- a/testsuite/tests/name_resolution/invalid_UA25-009/test.out
+++ b/testsuite/tests/name_resolution/invalid_UA25-009/test.out
@@ -1,0 +1,22 @@
+Analyzing test.adb
+##################
+
+Resolving xrefs for node <SubpSpec test.adb:4:4-4:31>
+*****************************************************
+
+
+Resolving xrefs for node <ParamSpec ["T"] test.adb:4:19-4:30>
+*************************************************************
+
+Expr: <AttributeRef test.adb:4:23-4:30>
+  references: <DefiningName test.adb:2:9-2:10>
+  type:       None
+Expr: <Id "T" test.adb:4:23-4:24>
+  references: <DefiningName test.adb:2:9-2:10>
+  type:       None
+Expr: <Id "Class" test.adb:4:25-4:30>
+  references: None
+  type:       None
+
+
+Done.

--- a/testsuite/tests/name_resolution/invalid_UA25-009/test.yaml
+++ b/testsuite/tests/name_resolution/invalid_UA25-009/test.yaml
@@ -1,0 +1,2 @@
+driver: name-resolution
+input_sources: [test.adb]


### PR DESCRIPTION
My changes for TA29-030 made LAL crash with an Assertion_Error (or worst in
production builds) when given the code pattern presented in the test case attached
to this commit: a parameter's type has the same name as the parameter itself. Note
that this is not valid Ada, however LAL shouldn't choke on it! This commit
resolves the issue.