### PR TITLE
UB16-053: Various fixes

### DIFF
--- a/ada/ast.py
+++ b/ada/ast.py
@@ -8169,6 +8169,9 @@ class Pragma(AdaNode):
                     ).then(
                         lambda decls: decls.at(decls.length - 1)
                     ).cast(BasicDecl).as_entity._.singleton
+                )._or(
+                    # Or else to the closest parent subprogram
+                    enclosing_program_unit.singleton
                 ),
 
                 # Or else it 's necessarily a program unit pragma

--- a/ada/ast.py
+++ b/ada/ast.py
@@ -6192,12 +6192,14 @@ class TypeDecl(BaseTypeDecl):
         return Entity.compute_primitives_env(include_self=True)
 
     @langkit_property(public=True, return_type=T.BasicDecl.entity.array)
-    def get_primitives(only_inherited=(Bool, False)):
+    def get_primitives(only_inherited=(Bool, False),
+                       include_predefined_operators=(Bool, False)):
         """
         Return the list of all primitive operations that are available on this
         type. If `only_inherited` is True, it will only return the primitives
         that are implicitly inherited by this type, discarding those explicitly
-        defined on this type.
+        defined on this type. Predefined operators are included in the result
+        iff `include_predefined_operators` is True. It defaults to False.
         """
         prim_env = Var(If(
             only_inherited,
@@ -6205,8 +6207,14 @@ class TypeDecl(BaseTypeDecl):
             Entity.primitives_env
         ))
 
-        bds = Var(prim_env.get(symbol=No(T.Symbol)).map(
+        all_prims = Var(prim_env.get(symbol=No(T.Symbol)).map(
             lambda t: t.cast(BasicDecl)
+        ))
+
+        bds = Var(If(
+            include_predefined_operators,
+            all_prims,
+            all_prims.filter(lambda p: Not(p.is_a(SyntheticSubpDecl)))
         ))
 
         # Make sure to return only one instance of each primitive: the most

--- a/ada/ast.py
+++ b/ada/ast.py
@@ -6766,12 +6766,7 @@ class SignedIntTypeDef(TypeDef):
     range = Field(type=T.RangeSpec)
     is_int_type = Property(True)
 
-    xref_equation = Property(
-        # We try to bind the range expression's type to the type we're
-        # defining. If not possible (for example because it's already of
-        # another type), fallback.
-        Entity.range.xref_equation
-    )
+    xref_equation = Property(Entity.range.xref_equation)
 
     @langkit_property()
     def discrete_range():
@@ -6815,7 +6810,7 @@ class SignedIntTypeDef(TypeDef):
             No(T.env_assoc.array)
         ))
 
-        return defaults.concat(specials)
+        return specials.concat(defaults)
 
     is_static = Property(Entity.range.range.is_static_expr)
 

--- a/testsuite/tests/name_resolution/builtin_binop/test.out
+++ b/testsuite/tests/name_resolution/builtin_binop/test.out
@@ -9,7 +9,7 @@ Resolving xrefs for node <TypeDecl ["Typ"] testbinop.adb:3:7-3:35>
 ******************************************************************
 
 Expr: <BinOp testbinop.adb:3:25-3:34>
-  type:       <TypeDecl ["Integer"] __standard:4:3-4:54>
+  type:       <TypeDecl ["root_integer"] __standard:124:3-124:38>
 Expr: <Int testbinop.adb:3:25-3:26>
   references: None
   type:       <TypeDecl ["Universal_Int_Type_"] __standard:121:3-121:45>

--- a/testsuite/tests/name_resolution/contract_pre_2/test.adb
+++ b/testsuite/tests/name_resolution/contract_pre_2/test.adb
@@ -1,0 +1,13 @@
+procedure Test is
+   function Foo (X : Integer) return Integer is
+      pragma Pre (X > 0);
+      pragma Precondition (X < 10);
+      pragma Post (Foo'Result > 0);
+      pragma Postcondition (Foo'Result < X);
+   begin
+      return X - 1;
+   end Foo;
+   pragma Test_Block;
+begin
+   null;
+end Test;

--- a/testsuite/tests/name_resolution/contract_pre_2/test.out
+++ b/testsuite/tests/name_resolution/contract_pre_2/test.out
@@ -1,0 +1,128 @@
+Analyzing test.adb
+##################
+
+Resolving xrefs for node <SubpSpec test.adb:2:4-2:45>
+*****************************************************
+
+Expr: <Id "Integer" test.adb:2:38-2:45>
+  references: <DefiningName __standard:4:8-4:15>
+  type:       None
+
+Resolving xrefs for node <ParamSpec ["X"] test.adb:2:18-2:29>
+*************************************************************
+
+Expr: <Id "Integer" test.adb:2:22-2:29>
+  references: <DefiningName __standard:4:8-4:15>
+  type:       None
+
+Resolving xrefs for node <PragmaNode test.adb:3:7-3:26>
+*******************************************************
+
+Expr: <Id "Pre" test.adb:3:14-3:17>
+  references: None
+  type:       None
+Expr: <RelationOp test.adb:3:19-3:24>
+  type:       <TypeDecl ["Boolean"] __standard:3:3-3:33>
+Expr: <Id "X" test.adb:3:19-3:20>
+  references: <DefiningName test.adb:2:18-2:19>
+  type:       <TypeDecl ["Integer"] __standard:4:3-4:54>
+Expr: <OpGt ">" test.adb:3:21-3:22>
+  references: None
+  type:       None
+Expr: <Int test.adb:3:23-3:24>
+  references: None
+  type:       <TypeDecl ["Universal_Int_Type_"] __standard:121:3-121:45>
+
+Resolving xrefs for node <PragmaNode test.adb:4:7-4:36>
+*******************************************************
+
+Expr: <Id "Precondition" test.adb:4:14-4:26>
+  references: None
+  type:       None
+Expr: <RelationOp test.adb:4:28-4:34>
+  type:       <TypeDecl ["Boolean"] __standard:3:3-3:33>
+Expr: <Id "X" test.adb:4:28-4:29>
+  references: <DefiningName test.adb:2:18-2:19>
+  type:       <TypeDecl ["Integer"] __standard:4:3-4:54>
+Expr: <OpLt "<" test.adb:4:30-4:31>
+  references: None
+  type:       None
+Expr: <Int test.adb:4:32-4:34>
+  references: None
+  type:       <TypeDecl ["Universal_Int_Type_"] __standard:121:3-121:45>
+
+Resolving xrefs for node <PragmaNode test.adb:5:7-5:36>
+*******************************************************
+
+Expr: <Id "Post" test.adb:5:14-5:18>
+  references: None
+  type:       None
+Expr: <RelationOp test.adb:5:20-5:34>
+  type:       <TypeDecl ["Boolean"] __standard:3:3-3:33>
+Expr: <AttributeRef test.adb:5:20-5:30>
+  references: None
+  type:       <TypeDecl ["Integer"] __standard:4:3-4:54>
+Expr: <Id "Foo" test.adb:5:20-5:23>
+  references: <DefiningName test.adb:2:13-2:16>
+  type:       None
+Expr: <Id "Result" test.adb:5:24-5:30>
+  references: None
+  type:       None
+Expr: <OpGt ">" test.adb:5:31-5:32>
+  references: None
+  type:       None
+Expr: <Int test.adb:5:33-5:34>
+  references: None
+  type:       <TypeDecl ["Universal_Int_Type_"] __standard:121:3-121:45>
+
+Resolving xrefs for node <PragmaNode test.adb:6:7-6:45>
+*******************************************************
+
+Expr: <Id "Postcondition" test.adb:6:14-6:27>
+  references: None
+  type:       None
+Expr: <RelationOp test.adb:6:29-6:43>
+  type:       <TypeDecl ["Boolean"] __standard:3:3-3:33>
+Expr: <AttributeRef test.adb:6:29-6:39>
+  references: None
+  type:       <TypeDecl ["Integer"] __standard:4:3-4:54>
+Expr: <Id "Foo" test.adb:6:29-6:32>
+  references: <DefiningName test.adb:2:13-2:16>
+  type:       None
+Expr: <Id "Result" test.adb:6:33-6:39>
+  references: None
+  type:       None
+Expr: <OpLt "<" test.adb:6:40-6:41>
+  references: None
+  type:       None
+Expr: <Id "X" test.adb:6:42-6:43>
+  references: <DefiningName test.adb:2:18-2:19>
+  type:       <TypeDecl ["Integer"] __standard:4:3-4:54>
+
+Resolving xrefs for node <ReturnStmt test.adb:8:7-8:20>
+*******************************************************
+
+Expr: <BinOp test.adb:8:14-8:19>
+  type:       <TypeDecl ["Integer"] __standard:4:3-4:54>
+Expr: <Id "X" test.adb:8:14-8:15>
+  references: <DefiningName test.adb:2:18-2:19>
+  type:       <TypeDecl ["Integer"] __standard:4:3-4:54>
+Expr: <OpMinus "-" test.adb:8:16-8:17>
+  references: None
+  type:       None
+Expr: <Int test.adb:8:18-8:19>
+  references: None
+  type:       <TypeDecl ["Universal_Int_Type_"] __standard:121:3-121:45>
+
+Resolving xrefs for node <EndName test.adb:9:8-9:11>
+****************************************************
+
+Expr: <EndName test.adb:9:8-9:11>
+  references: <DefiningName test.adb:2:13-2:16>
+  type:       None
+Expr: <Id "Foo" test.adb:9:8-9:11>
+  references: <DefiningName test.adb:2:13-2:16>
+  type:       None
+
+
+Done.

--- a/testsuite/tests/name_resolution/contract_pre_2/test.yaml
+++ b/testsuite/tests/name_resolution/contract_pre_2/test.yaml
@@ -1,0 +1,2 @@
+driver: name-resolution
+input_sources: [test.adb]

--- a/testsuite/tests/name_resolution/operators_6/test.out
+++ b/testsuite/tests/name_resolution/operators_6/test.out
@@ -5,7 +5,7 @@ Resolving xrefs for node <TypeDecl ["My_Integer"] test.adb:2:4-2:56>
 ********************************************************************
 
 Expr: <BinOp test.adb:2:29-2:55>
-  type:       <TypeDecl ["Integer"] __standard:4:3-4:54>
+  type:       <TypeDecl ["root_integer"] __standard:124:3-124:38>
 Expr: <UnOp test.adb:2:29-2:40>
   type:       <TypeDecl ["root_integer"] __standard:124:3-124:38>
 Expr: <OpMinus "-" test.adb:2:29-2:30>

--- a/testsuite/tests/name_resolution/record_rep_clause/test.out
+++ b/testsuite/tests/name_resolution/record_rep_clause/test.out
@@ -36,7 +36,7 @@ Expr: <Int test.adb:8:12-8:13>
   references: None
   type:       <TypeDecl ["Universal_Int_Type_"] __standard:121:3-121:45>
 Expr: <BinOp test.adb:8:20-8:27>
-  type:       <TypeDecl ["Integer"] __standard:4:3-4:54>
+  type:       <TypeDecl ["root_integer"] __standard:124:3-124:38>
 Expr: <Int test.adb:8:20-8:21>
   references: None
   type:       <TypeDecl ["Universal_Int_Type_"] __standard:121:3-121:45>
@@ -57,7 +57,7 @@ Expr: <Int test.adb:9:12-9:13>
   references: None
   type:       <TypeDecl ["Universal_Int_Type_"] __standard:121:3-121:45>
 Expr: <BinOp test.adb:9:20-9:28>
-  type:       <TypeDecl ["Integer"] __standard:4:3-4:54>
+  type:       <TypeDecl ["root_integer"] __standard:124:3-124:38>
 Expr: <Int test.adb:9:20-9:22>
   references: None
   type:       <TypeDecl ["Universal_Int_Type_"] __standard:121:3-121:45>

--- a/testsuite/tests/properties/inherited_primitives/test.out
+++ b/testsuite/tests/properties/inherited_primitives/test.out
@@ -1,23 +1,15 @@
 Primitives inherited by <TypeDecl ["U"] test.adb:10:7-10:42>:
   <ExprFunction ["F"] test.adb:5:7-5:42>
   <NullSubpDecl ["G"] test.adb:6:7-6:35>
-  <SyntheticSubpDecl [] test.adb:3:17-3:35>
-  <SyntheticSubpDecl [] test.adb:3:17-3:35>
 Primitives inherited by <TypeDecl ["U"] test.adb:14:7-14:42>:
   <NullSubpDecl ["G"] test.adb:6:7-6:35>
-  <SyntheticSubpDecl [] test.adb:3:17-3:35>
-  <SyntheticSubpDecl [] test.adb:3:17-3:35>
   <ExprFunction ["F"] test.adb:16:7-16:53>
 Primitives inherited by <TypeDecl ["U"] test.adb:32:7-32:42>:
   <ExprFunction ["F"] test.adb:16:7-16:53>
   <NullSubpDecl ["G"] test.adb:6:7-6:35>
-  <SyntheticSubpDecl [] test.adb:3:17-3:35>
-  <SyntheticSubpDecl [] test.adb:3:17-3:35>
 Primitives inherited by <TypeDecl ["U"] test.adb:36:7-36:50>:
   <ExprFunction ["F"] test.adb:16:7-16:53>
   <NullSubpDecl ["G"] test.adb:6:7-6:35>
-  <SyntheticSubpDecl [] test.adb:3:17-3:35>
-  <SyntheticSubpDecl [] test.adb:3:17-3:35>
   <NullSubpDecl ["A"] test.adb:22:7-22:35>
   <NullSubpDecl ["B"] test.adb:26:7-26:35>
 Done

--- a/testsuite/tests/properties/is_inherited_primitive/test.out
+++ b/testsuite/tests/properties/is_inherited_primitive/test.out
@@ -1,12 +1,8 @@
 == test.adb ==
 For <TypeDecl ["Parent"] test.adb:3:7-3:41>, <SubpDecl ["Get1"] test.adb:5:7-5:49> is not inherited
 For <TypeDecl ["Parent"] test.adb:3:7-3:41>, <SubpDecl ["Get2"] test.adb:6:7-6:49> is not inherited
-For <TypeDecl ["Parent"] test.adb:3:7-3:41>, <SyntheticSubpDecl [] test.adb:3:22-3:40> is not inherited
-For <TypeDecl ["Parent"] test.adb:3:7-3:41>, <SyntheticSubpDecl [] test.adb:3:22-3:40> is not inherited
 For <TypeDecl ["Child"] test.adb:16:7-16:52>, <SubpDecl ["Get1"] test.adb:5:7-5:49> is inherited
 For <TypeDecl ["Child"] test.adb:16:7-16:52>, <SubpDecl ["Get2"] test.adb:6:7-6:49> is inherited
-For <TypeDecl ["Child"] test.adb:16:7-16:52>, <SyntheticSubpDecl [] test.adb:3:22-3:40> is inherited
-For <TypeDecl ["Child"] test.adb:16:7-16:52>, <SyntheticSubpDecl [] test.adb:3:22-3:40> is inherited
 For <TypeDecl ["Child"] test.adb:16:7-16:52>, <SubpDecl ["Get1"] test.adb:18:7-18:59> is not inherited
 
 Done


### PR DESCRIPTION
The main reason is that it is causing trouble in some tools that don't expect
SyntheticSubpDecl nodes to be returned here. Besides I also think it makes more
sense not to output them by default.