### PR TITLE
Add Ada 2022 iterator_filter support for iterator specification

### DIFF
--- a/ada/ast.py
+++ b/ada/ast.py
@@ -14755,6 +14755,7 @@ class ForLoopSpec(LoopSpec):
     loop_type = Field(type=IterType)
     has_reverse = Field(type=Reverse)
     iter_expr = Field(type=T.AdaNode)
+    iter_filter = Field(type=T.Expr)
 
     @langkit_property(return_type=Bool)
     def is_iterated_assoc_spec():
@@ -14854,6 +14855,11 @@ class ForLoopSpec(LoopSpec):
 
                 LogicFalse()
             ))
+        ) & If(
+            Entity.iter_filter.is_null,
+            LogicTrue(),
+            Self.bool_bind(Entity.iter_filter.type_var)
+            & Entity.iter_filter.sub_equation
         )
 
     @langkit_property(return_type=Equation, dynamic_vars=[env, origin])

--- a/ada/grammar.py
+++ b/ada/grammar.py
@@ -1049,7 +1049,8 @@ A.add_rules(
         ForLoopVarDecl(A.defining_id, Opt(":", A.subtype_indication)),
         IterType.alt_in("in") | IterType.alt_of("of"),
         Reverse("reverse"),
-        A.discrete_range | A.discrete_subtype_indication | A.name
+        A.discrete_range | A.discrete_subtype_indication | A.name,
+        Opt("when", A.expr)
     ),
 
     quantified_expr=QuantifiedExpr(

--- a/testsuite/tests/ada_api/dump/test.out
+++ b/testsuite/tests/ada_api/dump/test.out
@@ -91,6 +91,7 @@ CompilationUnit[1:2-5:11]
 |  |  |  |  |  |  |  ReverseAbsent[2:26-2:26]
 |  |  |  |  |  |  |f_iter_expr:
 |  |  |  |  |  |  |  Id[2:27-2:28]: A
+|  |  |  |  |  |  |f_iter_filter: <null>
 |  |  |  |  |  |f_stmts:
 |  |  |  |  |  |  StmtList[3:9-3:24]
 |  |  |  |  |  |  |  CallStmt[3:9-3:24]

--- a/testsuite/tests/name_resolution/iterated_component_association/iterassoc_filter.adb
+++ b/testsuite/tests/name_resolution/iterated_component_association/iterassoc_filter.adb
@@ -1,0 +1,26 @@
+procedure Iterassoc_Filter is
+   type R is range 1 .. 5;
+   type A is array (R) of Float;
+
+   X : A := (1.0, 2.0, 3.0, 4.0, 5.0);
+
+   M : A := (for I in R when X (I) >= 3.0 => X (I) * X (I));
+   pragma Test_Statement;
+
+   O : A := (for F : Float of X when F >= 3.0 => F * F);
+   pragma Test_Statement;
+
+   P : A := (for F of X when F >= 3.0 => F * F);
+   pragma Test_Statement;
+
+
+   type AA is array (R, R) of Float;
+
+   Q : AA :=
+     (for I in R when X (I) >= 3.0 =>
+       (for J in R when X (J) >= 3.0 => X (I) * X (J)));
+   pragma Test_Statement;
+
+begin
+   null;
+end Iterassoc_Filter;

--- a/testsuite/tests/name_resolution/iterated_component_association/test.out
+++ b/testsuite/tests/name_resolution/iterated_component_association/test.out
@@ -231,4 +231,205 @@ Expr: <Id "J" iterassoc.adb:27:39-27:40>
   type:       <TypeDecl ["R"] iterassoc.adb:2:4-2:27>
 
 
+Analyzing iterassoc_filter.adb
+##############################
+
+Resolving xrefs for node <ObjectDecl ["M"] iterassoc_filter.adb:7:4-7:61>
+*************************************************************************
+
+Expr: <Id "A" iterassoc_filter.adb:7:8-7:9>
+  references: <DefiningName iterassoc_filter.adb:3:9-3:10>
+  type:       None
+Expr: <Aggregate iterassoc_filter.adb:7:13-7:60>
+  type:       <TypeDecl ["A"] iterassoc_filter.adb:3:4-3:33>
+Expr: <Id "R" iterassoc_filter.adb:7:23-7:24>
+  references: <DefiningName iterassoc_filter.adb:2:9-2:10>
+  type:       <TypeDecl ["R"] iterassoc_filter.adb:2:4-2:27>
+Expr: <RelationOp iterassoc_filter.adb:7:30-7:42>
+  type:       <TypeDecl ["Boolean"] __standard:3:3-3:33>
+Expr: <CallExpr iterassoc_filter.adb:7:30-7:35>
+  references: <DefiningName iterassoc_filter.adb:5:4-5:5>
+  type:       <TypeDecl ["Float"] __standard:14:3-15:51>
+Expr: <Id "X" iterassoc_filter.adb:7:30-7:31>
+  references: <DefiningName iterassoc_filter.adb:5:4-5:5>
+  type:       <TypeDecl ["A"] iterassoc_filter.adb:3:4-3:33>
+Expr: <Id "I" iterassoc_filter.adb:7:33-7:34>
+  references: <DefiningName iterassoc_filter.adb:7:18-7:19>
+  type:       <TypeDecl ["R"] iterassoc_filter.adb:2:4-2:27>
+Expr: <OpGte ">=" iterassoc_filter.adb:7:36-7:38>
+  references: None
+  type:       None
+Expr: <Real iterassoc_filter.adb:7:39-7:42>
+  references: None
+  type:       <TypeDecl ["Universal_Real_Type_"] __standard:122:3-122:42>
+Expr: <BinOp iterassoc_filter.adb:7:46-7:59>
+  type:       <TypeDecl ["Float"] __standard:14:3-15:51>
+Expr: <CallExpr iterassoc_filter.adb:7:46-7:51>
+  references: <DefiningName iterassoc_filter.adb:5:4-5:5>
+  type:       <TypeDecl ["Float"] __standard:14:3-15:51>
+Expr: <Id "X" iterassoc_filter.adb:7:46-7:47>
+  references: <DefiningName iterassoc_filter.adb:5:4-5:5>
+  type:       <TypeDecl ["A"] iterassoc_filter.adb:3:4-3:33>
+Expr: <Id "I" iterassoc_filter.adb:7:49-7:50>
+  references: <DefiningName iterassoc_filter.adb:7:18-7:19>
+  type:       <TypeDecl ["R"] iterassoc_filter.adb:2:4-2:27>
+Expr: <OpMult "*" iterassoc_filter.adb:7:52-7:53>
+  references: None
+  type:       None
+Expr: <CallExpr iterassoc_filter.adb:7:54-7:59>
+  references: <DefiningName iterassoc_filter.adb:5:4-5:5>
+  type:       <TypeDecl ["Float"] __standard:14:3-15:51>
+Expr: <Id "X" iterassoc_filter.adb:7:54-7:55>
+  references: <DefiningName iterassoc_filter.adb:5:4-5:5>
+  type:       <TypeDecl ["A"] iterassoc_filter.adb:3:4-3:33>
+Expr: <Id "I" iterassoc_filter.adb:7:57-7:58>
+  references: <DefiningName iterassoc_filter.adb:7:18-7:19>
+  type:       <TypeDecl ["R"] iterassoc_filter.adb:2:4-2:27>
+
+Resolving xrefs for node <ObjectDecl ["O"] iterassoc_filter.adb:10:4-10:57>
+***************************************************************************
+
+Expr: <Id "A" iterassoc_filter.adb:10:8-10:9>
+  references: <DefiningName iterassoc_filter.adb:3:9-3:10>
+  type:       None
+Expr: <Aggregate iterassoc_filter.adb:10:13-10:56>
+  type:       <TypeDecl ["A"] iterassoc_filter.adb:3:4-3:33>
+Expr: <Id "Float" iterassoc_filter.adb:10:22-10:27>
+  references: None
+  type:       None
+Expr: <Id "X" iterassoc_filter.adb:10:31-10:32>
+  references: <DefiningName iterassoc_filter.adb:5:4-5:5>
+  type:       <TypeDecl ["A"] iterassoc_filter.adb:3:4-3:33>
+Expr: <RelationOp iterassoc_filter.adb:10:38-10:46>
+  type:       <TypeDecl ["Boolean"] __standard:3:3-3:33>
+Expr: <Id "F" iterassoc_filter.adb:10:38-10:39>
+  references: <DefiningName iterassoc_filter.adb:10:18-10:19>
+  type:       <TypeDecl ["Float"] __standard:14:3-15:51>
+Expr: <OpGte ">=" iterassoc_filter.adb:10:40-10:42>
+  references: None
+  type:       None
+Expr: <Real iterassoc_filter.adb:10:43-10:46>
+  references: None
+  type:       <TypeDecl ["Universal_Real_Type_"] __standard:122:3-122:42>
+Expr: <BinOp iterassoc_filter.adb:10:50-10:55>
+  type:       <TypeDecl ["Float"] __standard:14:3-15:51>
+Expr: <Id "F" iterassoc_filter.adb:10:50-10:51>
+  references: <DefiningName iterassoc_filter.adb:10:18-10:19>
+  type:       <TypeDecl ["Float"] __standard:14:3-15:51>
+Expr: <OpMult "*" iterassoc_filter.adb:10:52-10:53>
+  references: None
+  type:       None
+Expr: <Id "F" iterassoc_filter.adb:10:54-10:55>
+  references: <DefiningName iterassoc_filter.adb:10:18-10:19>
+  type:       <TypeDecl ["Float"] __standard:14:3-15:51>
+
+Resolving xrefs for node <ObjectDecl ["P"] iterassoc_filter.adb:13:4-13:49>
+***************************************************************************
+
+Expr: <Id "A" iterassoc_filter.adb:13:8-13:9>
+  references: <DefiningName iterassoc_filter.adb:3:9-3:10>
+  type:       None
+Expr: <Aggregate iterassoc_filter.adb:13:13-13:48>
+  type:       <TypeDecl ["A"] iterassoc_filter.adb:3:4-3:33>
+Expr: <Id "X" iterassoc_filter.adb:13:23-13:24>
+  references: <DefiningName iterassoc_filter.adb:5:4-5:5>
+  type:       <TypeDecl ["A"] iterassoc_filter.adb:3:4-3:33>
+Expr: <RelationOp iterassoc_filter.adb:13:30-13:38>
+  type:       <TypeDecl ["Boolean"] __standard:3:3-3:33>
+Expr: <Id "F" iterassoc_filter.adb:13:30-13:31>
+  references: <DefiningName iterassoc_filter.adb:13:18-13:19>
+  type:       <TypeDecl ["Float"] __standard:14:3-15:51>
+Expr: <OpGte ">=" iterassoc_filter.adb:13:32-13:34>
+  references: None
+  type:       None
+Expr: <Real iterassoc_filter.adb:13:35-13:38>
+  references: None
+  type:       <TypeDecl ["Universal_Real_Type_"] __standard:122:3-122:42>
+Expr: <BinOp iterassoc_filter.adb:13:42-13:47>
+  type:       <TypeDecl ["Float"] __standard:14:3-15:51>
+Expr: <Id "F" iterassoc_filter.adb:13:42-13:43>
+  references: <DefiningName iterassoc_filter.adb:13:18-13:19>
+  type:       <TypeDecl ["Float"] __standard:14:3-15:51>
+Expr: <OpMult "*" iterassoc_filter.adb:13:44-13:45>
+  references: None
+  type:       None
+Expr: <Id "F" iterassoc_filter.adb:13:46-13:47>
+  references: <DefiningName iterassoc_filter.adb:13:18-13:19>
+  type:       <TypeDecl ["Float"] __standard:14:3-15:51>
+
+Resolving xrefs for node <ObjectDecl ["Q"] iterassoc_filter.adb:19:4-21:57>
+***************************************************************************
+
+Expr: <Id "AA" iterassoc_filter.adb:19:8-19:10>
+  references: <DefiningName iterassoc_filter.adb:17:9-17:11>
+  type:       None
+Expr: <Aggregate iterassoc_filter.adb:20:6-21:56>
+  type:       <TypeDecl ["AA"] iterassoc_filter.adb:17:4-17:37>
+Expr: <Id "R" iterassoc_filter.adb:20:16-20:17>
+  references: <DefiningName iterassoc_filter.adb:2:9-2:10>
+  type:       <TypeDecl ["R"] iterassoc_filter.adb:2:4-2:27>
+Expr: <RelationOp iterassoc_filter.adb:20:23-20:35>
+  type:       <TypeDecl ["Boolean"] __standard:3:3-3:33>
+Expr: <CallExpr iterassoc_filter.adb:20:23-20:28>
+  references: <DefiningName iterassoc_filter.adb:5:4-5:5>
+  type:       <TypeDecl ["Float"] __standard:14:3-15:51>
+Expr: <Id "X" iterassoc_filter.adb:20:23-20:24>
+  references: <DefiningName iterassoc_filter.adb:5:4-5:5>
+  type:       <TypeDecl ["A"] iterassoc_filter.adb:3:4-3:33>
+Expr: <Id "I" iterassoc_filter.adb:20:26-20:27>
+  references: <DefiningName iterassoc_filter.adb:20:11-20:12>
+  type:       <TypeDecl ["R"] iterassoc_filter.adb:2:4-2:27>
+Expr: <OpGte ">=" iterassoc_filter.adb:20:29-20:31>
+  references: None
+  type:       None
+Expr: <Real iterassoc_filter.adb:20:32-20:35>
+  references: None
+  type:       <TypeDecl ["Universal_Real_Type_"] __standard:122:3-122:42>
+Expr: <Aggregate iterassoc_filter.adb:21:8-21:55>
+  type:       None
+Expr: <Id "R" iterassoc_filter.adb:21:18-21:19>
+  references: <DefiningName iterassoc_filter.adb:2:9-2:10>
+  type:       <TypeDecl ["R"] iterassoc_filter.adb:2:4-2:27>
+Expr: <RelationOp iterassoc_filter.adb:21:25-21:37>
+  type:       <TypeDecl ["Boolean"] __standard:3:3-3:33>
+Expr: <CallExpr iterassoc_filter.adb:21:25-21:30>
+  references: <DefiningName iterassoc_filter.adb:5:4-5:5>
+  type:       <TypeDecl ["Float"] __standard:14:3-15:51>
+Expr: <Id "X" iterassoc_filter.adb:21:25-21:26>
+  references: <DefiningName iterassoc_filter.adb:5:4-5:5>
+  type:       <TypeDecl ["A"] iterassoc_filter.adb:3:4-3:33>
+Expr: <Id "J" iterassoc_filter.adb:21:28-21:29>
+  references: <DefiningName iterassoc_filter.adb:21:13-21:14>
+  type:       <TypeDecl ["R"] iterassoc_filter.adb:2:4-2:27>
+Expr: <OpGte ">=" iterassoc_filter.adb:21:31-21:33>
+  references: None
+  type:       None
+Expr: <Real iterassoc_filter.adb:21:34-21:37>
+  references: None
+  type:       <TypeDecl ["Universal_Real_Type_"] __standard:122:3-122:42>
+Expr: <BinOp iterassoc_filter.adb:21:41-21:54>
+  type:       <TypeDecl ["Float"] __standard:14:3-15:51>
+Expr: <CallExpr iterassoc_filter.adb:21:41-21:46>
+  references: <DefiningName iterassoc_filter.adb:5:4-5:5>
+  type:       <TypeDecl ["Float"] __standard:14:3-15:51>
+Expr: <Id "X" iterassoc_filter.adb:21:41-21:42>
+  references: <DefiningName iterassoc_filter.adb:5:4-5:5>
+  type:       <TypeDecl ["A"] iterassoc_filter.adb:3:4-3:33>
+Expr: <Id "I" iterassoc_filter.adb:21:44-21:45>
+  references: <DefiningName iterassoc_filter.adb:20:11-20:12>
+  type:       <TypeDecl ["R"] iterassoc_filter.adb:2:4-2:27>
+Expr: <OpMult "*" iterassoc_filter.adb:21:47-21:48>
+  references: None
+  type:       None
+Expr: <CallExpr iterassoc_filter.adb:21:49-21:54>
+  references: <DefiningName iterassoc_filter.adb:5:4-5:5>
+  type:       <TypeDecl ["Float"] __standard:14:3-15:51>
+Expr: <Id "X" iterassoc_filter.adb:21:49-21:50>
+  references: <DefiningName iterassoc_filter.adb:5:4-5:5>
+  type:       <TypeDecl ["A"] iterassoc_filter.adb:3:4-3:33>
+Expr: <Id "J" iterassoc_filter.adb:21:52-21:53>
+  references: <DefiningName iterassoc_filter.adb:21:13-21:14>
+  type:       <TypeDecl ["R"] iterassoc_filter.adb:2:4-2:27>
+
+
 Done.

--- a/testsuite/tests/name_resolution/iterated_component_association/test.yaml
+++ b/testsuite/tests/name_resolution/iterated_component_association/test.yaml
@@ -1,2 +1,2 @@
 driver: name-resolution
-input_sources: [iterassoc.adb]
+input_sources: [iterassoc.adb, iterassoc_filter.adb]

--- a/testsuite/tests/parser/expression_5/test.out
+++ b/testsuite/tests/parser/expression_5/test.out
@@ -28,6 +28,7 @@ BinOp[1:1-1:53]
 |  |  |  |  |  |  ReverseAbsent[1:23-1:23]
 |  |  |  |  |  |f_iter_expr:
 |  |  |  |  |  |  Id[1:24-1:25]: B
+|  |  |  |  |  |f_iter_filter: <null>
 |  |  |  |  |f_expr:
 |  |  |  |  |  RelationOp[1:29-1:35]
 |  |  |  |  |  |f_left:

--- a/testsuite/tests/parser/for_loop_parameter_spec_0/test.out
+++ b/testsuite/tests/parser/for_loop_parameter_spec_0/test.out
@@ -23,3 +23,4 @@ ForLoopSpec[1:1-1:21]
 |  |  OpDoubleDot[1:14-1:16]
 |  |f_right:
 |  |  Id[1:17-1:21]: Last
+|f_iter_filter: <null>

--- a/testsuite/tests/parser/for_loop_parameter_spec_1/test.out
+++ b/testsuite/tests/parser/for_loop_parameter_spec_1/test.out
@@ -18,3 +18,4 @@ ForLoopSpec[1:1-1:19]
 |  ReverseAbsent[1:15-1:15]
 |f_iter_expr:
 |  Id[1:16-1:19]: Foo
+|f_iter_filter: <null>

--- a/testsuite/tests/parser/loop_statement_0/test.out
+++ b/testsuite/tests/parser/loop_statement_0/test.out
@@ -22,6 +22,7 @@ NamedStmt[1:1-1:35]
 |  |  |  ReverseAbsent[1:12-1:12]
 |  |  |f_iter_expr:
 |  |  |  Id[1:13-1:14]: B
+|  |  |f_iter_filter: <null>
 |  |f_stmts:
 |  |  StmtList[1:20-1:25]
 |  |  |  NullStmt[1:20-1:25]

--- a/testsuite/tests/parser/loop_statement_1/test.out
+++ b/testsuite/tests/parser/loop_statement_1/test.out
@@ -30,6 +30,7 @@ ForLoopStmt[1:1-1:52]
 |  |  |  |  |  |  OpDoubleDot[1:26-1:28]
 |  |  |  |  |  |f_right:
 |  |  |  |  |  |  Int[1:29-1:31]: 16
+|  |f_iter_filter: <null>
 |f_stmts:
 |  StmtList[1:37-1:42]
 |  |  NullStmt[1:37-1:42]

--- a/user_manual/changes/UB16-009.yaml
+++ b/user_manual/changes/UB16-009.yaml
@@ -1,0 +1,5 @@
+type: new-feature
+title: Iterator filter support (Ada 2022)
+description: |
+    Add support for the iterator filter feature introduced in Ada 2022.
+date: 2021-12-02


### PR DESCRIPTION
This patch implements the iterator_filter feature introduced in Ada
2022, AI12-0250.

TN: UB16-009