### PR TITLE
Fix `EntrySpec` xref_equation

### DIFF
--- a/ada/ast.py
+++ b/ada/ast.py
@@ -14695,6 +14695,11 @@ class EntrySpec(BaseSubpSpec):
     )
     returns = Property(No(T.TypeExpr.entity))
 
+    xref_equation = Property(Entity.family_type.then(
+        lambda r: r.sub_equation,
+        default_val=LogicTrue()
+    ))
+
 
 class Quantifier(AdaNode):
     """

--- a/testsuite/tests/name_resolution/index_attr/test.out
+++ b/testsuite/tests/name_resolution/index_attr/test.out
@@ -5,7 +5,7 @@ Resolving xrefs for node <EntrySpec index.ads:10:9-10:31>
 *********************************************************
 
 Expr: <Id "Entry_Id_Mod" index.ads:10:18-10:30>
-  references: None
+  references: <DefiningName index.ads:4:10-4:22>
   type:       None
 
 Resolving xrefs for node <AspectAssoc index.ads:11:11-11:29>
@@ -60,7 +60,7 @@ Resolving xrefs for node <EntrySpec index.ads:13:9-13:31>
 *********************************************************
 
 Expr: <Id "Entry_Id_Sub" index.ads:13:18-13:30>
-  references: None
+  references: <DefiningName index.ads:5:13-5:25>
   type:       None
 
 Resolving xrefs for node <AspectAssoc index.ads:14:11-14:31>

--- a/user_manual/changes/UC02-047.yaml
+++ b/user_manual/changes/UC02-047.yaml
@@ -1,0 +1,6 @@
+type: bugfix
+title: Resolve references to entry families.
+description: |
+    This change fixes a bug where references to entry families were missing from
+    name resolution.
+date: 2021-12-08


### PR DESCRIPTION
This change fixes the xref_equation for `EntrySpec` name resolution.

TN: UC02-047