### PR TITLE
Add `Default_Initial_Condition` aspect nameres tests

### DIFF
--- a/testsuite/tests/name_resolution/default_initial_condition/dic.ads
+++ b/testsuite/tests/name_resolution/default_initial_condition/dic.ads
@@ -1,0 +1,13 @@
+package Dic is
+   type Set1 is private
+      with Default_Initial_Condition => Is_Empty (Set1);
+   pragma Test_Block;
+
+   function Is_Empty (S : Set1) return Boolean;
+
+   type Set2 is private;
+   pragma Default_Initial_Condition (Is_Empty (Set2));
+   pragma Test_Statement;
+
+   function Is_Empty (S : Set2) return Boolean;
+end Dic;

--- a/testsuite/tests/name_resolution/default_initial_condition/test.out
+++ b/testsuite/tests/name_resolution/default_initial_condition/test.out
@@ -1,0 +1,37 @@
+Analyzing dic.ads
+#################
+
+Resolving xrefs for node <AspectAssoc dic.ads:3:12-3:56>
+********************************************************
+
+Expr: <Id "Default_Initial_Condition" dic.ads:3:12-3:37>
+  references: None
+  type:       None
+Expr: <CallExpr dic.ads:3:41-3:56>
+  references: <DefiningName dic.ads:6:13-6:21>
+  type:       <TypeDecl ["Boolean"] __standard:3:3-3:33>
+Expr: <Id "Is_Empty" dic.ads:3:41-3:49>
+  references: <DefiningName dic.ads:6:13-6:21>
+  type:       <TypeDecl ["Boolean"] __standard:3:3-3:33>
+Expr: <Id "Set1" dic.ads:3:51-3:55>
+  references: <DefiningName dic.ads:2:9-2:13>
+  type:       <TypeDecl ["Set1"] dic.ads:2:4-3:57>
+
+Resolving xrefs for node <PragmaNode dic.ads:9:4-9:55>
+******************************************************
+
+Expr: <Id "Default_Initial_Condition" dic.ads:9:11-9:36>
+  references: None
+  type:       None
+Expr: <CallExpr dic.ads:9:38-9:53>
+  references: <DefiningName dic.ads:12:13-12:21>
+  type:       <TypeDecl ["Boolean"] __standard:3:3-3:33>
+Expr: <Id "Is_Empty" dic.ads:9:38-9:46>
+  references: <DefiningName dic.ads:12:13-12:21>
+  type:       <TypeDecl ["Boolean"] __standard:3:3-3:33>
+Expr: <Id "Set2" dic.ads:9:48-9:52>
+  references: <DefiningName dic.ads:8:9-8:13>
+  type:       <TypeDecl ["Set2"] dic.ads:8:4-8:25>
+
+
+Done.

--- a/testsuite/tests/name_resolution/default_initial_condition/test.yaml
+++ b/testsuite/tests/name_resolution/default_initial_condition/test.yaml
@@ -1,0 +1,2 @@
+driver: name-resolution
+input_sources: [dic.ads]


### PR DESCRIPTION
As already supported by libadalang, this patch only adds some tests
for the `Default_Initial_Condition` aspect, introduced by the Ada 2022
standard.

See also:
http://www.ada-auth.org/cgi-bin/cvsweb.cgi/ai12s/ai12-0265-1.txt.

TN: V103-013