### PR TITLE
Ada 2022 defaults for generic formal types support

### DIFF
--- a/ada/ast.py
+++ b/ada/ast.py
@@ -4694,6 +4694,7 @@ class BaseTypeDecl(BasicDecl):
                 has_not_null=T.NotNullAbsent.new(),
                 type_decl=Self
             ),
+            default_type=No(T.Name),
             aspects=No(T.AspectSpec)
         ).cast(T.BaseTypeDecl).as_entity
 
@@ -5807,6 +5808,7 @@ class TypeDecl(BaseTypeDecl):
     """
     discriminants = Field(type=T.DiscriminantPart)
     type_def = Field(type=T.TypeDef)
+    default_type = Field(type=T.Name)
     aspects = Field(type=T.AspectSpec)
 
     is_iterable_type = Property(
@@ -6084,7 +6086,10 @@ class TypeDecl(BaseTypeDecl):
     @langkit_property(return_type=Equation)
     def xref_equation():
         # TODO: Handle discriminants
-        return Entity.type_def.sub_equation
+        return Entity.type_def.sub_equation & Entity.default_type.then(
+            lambda dt: dt.sub_equation,
+            default_val=LogicTrue()
+        )
 
     is_discrete_type = Property(Entity.type_def.is_discrete_type)
 

--- a/ada/grammar.py
+++ b/ada/grammar.py
@@ -314,7 +314,7 @@ A.add_rules(
     anonymous_type_decl=AnonymousTypeDecl(
         Null(A.defining_id), Null(A.discriminant_part),
         Or(A.array_type_def, A.access_def),
-        Null(A.aspect_spec)
+        Null(A.name), Null(A.aspect_spec)
     ),
 
     type_decl=Or(
@@ -331,6 +331,7 @@ A.add_rules(
                     "private"
                 ),
             ),
+            Opt("or", "use", A.name),
             A.aspect_spec, sc()
         ),
         IncompleteTaggedTypeDecl(

--- a/testsuite/tests/lexical_envs/records/test.out
+++ b/testsuite/tests/lexical_envs/records/test.out
@@ -82,6 +82,7 @@ CompilationUnit[1:1-11:9]
 |  |  |  |  |  |  |  |  |  |  |f_default_expr: <null>
 |  |  |  |  |  |  |  |  |  |  |f_aspects: <null>
 |  |  |  |  |  |  |  |  |f_variant_part: <null>
+|  |  |  |  |  |f_default_type: <null>
 |  |  |  |  |  |f_aspects: <null>
 |  |  |  |  |  TypeDecl[7:4-10:15]
 |  |  |  |  |  |f_name:
@@ -173,6 +174,7 @@ CompilationUnit[1:1-11:9]
 |  |  |  |  |  |  |  |  |  |  |f_default_expr: <null>
 |  |  |  |  |  |  |  |  |  |  |f_aspects: <null>
 |  |  |  |  |  |  |  |  |f_variant_part: <null>
+|  |  |  |  |  |f_default_type: <null>
 |  |  |  |  |  |f_aspects: <null>
 |  |  |f_private_part: <null>
 |  |  |f_end_name:

--- a/testsuite/tests/name_resolution/generic_formal_types_defaults/set.adb
+++ b/testsuite/tests/name_resolution/generic_formal_types_defaults/set.adb
@@ -1,0 +1,17 @@
+procedure Set is
+   generic
+      type Item_Type is private;
+      type Item_Count is range <> or use Natural;
+      pragma Test_Block;
+      I : Item_Count;
+   package Pck is
+   end Pck;
+
+   package New_Pck1 is new Pck (Item_Type => Integer, I => 1);
+   pragma Test_Statement;
+
+   package New_Pck2 is new Pck (Integer, Integer, -1);
+   pragma Test_Statement;
+begin
+   null;
+end Set;

--- a/testsuite/tests/name_resolution/generic_formal_types_defaults/test.out
+++ b/testsuite/tests/name_resolution/generic_formal_types_defaults/test.out
@@ -1,0 +1,54 @@
+Analyzing set.adb
+#################
+
+Resolving xrefs for node <TypeDecl ["Item_Count"] set.adb:4:7-4:50>
+*******************************************************************
+
+Expr: <BoxExpr set.adb:4:32-4:34>
+  type:       None
+Expr: <Id "Natural" set.adb:4:42-4:49>
+  references: <DefiningName __standard:5:11-5:18>
+  type:       <SubtypeDecl ["Natural"] __standard:5:3-5:57>
+
+Resolving xrefs for node <GenericPackageInstantiation ["New_Pck1"] set.adb:10:4-10:63>
+**************************************************************************************
+
+Expr: <Id "Pck" set.adb:10:28-10:31>
+  references: <DefiningName set.adb:7:12-7:15>
+  type:       None
+Expr: <Id "Item_Type" set.adb:10:33-10:42>
+  references: <DefiningName set.adb:3:12-3:21>
+  type:       None
+Expr: <Id "Integer" set.adb:10:46-10:53>
+  references: <DefiningName __standard:4:8-4:15>
+  type:       None
+Expr: <Id "I" set.adb:10:55-10:56>
+  references: <DefiningName set.adb:6:7-6:8>
+  type:       None
+Expr: <Int set.adb:10:60-10:61>
+  references: None
+  type:       <TypeDecl ["Universal_Int_Type_"] __standard:121:3-121:45>
+
+Resolving xrefs for node <GenericPackageInstantiation ["New_Pck2"] set.adb:13:4-13:55>
+**************************************************************************************
+
+Expr: <Id "Pck" set.adb:13:28-13:31>
+  references: <DefiningName set.adb:7:12-7:15>
+  type:       None
+Expr: <Id "Integer" set.adb:13:33-13:40>
+  references: <DefiningName __standard:4:8-4:15>
+  type:       None
+Expr: <Id "Integer" set.adb:13:42-13:49>
+  references: <DefiningName __standard:4:8-4:15>
+  type:       None
+Expr: <UnOp set.adb:13:51-13:53>
+  type:       <TypeDecl ["Universal_Int_Type_"] __standard:121:3-121:45>
+Expr: <OpMinus "-" set.adb:13:51-13:52>
+  references: None
+  type:       None
+Expr: <Int set.adb:13:52-13:53>
+  references: None
+  type:       <TypeDecl ["Universal_Int_Type_"] __standard:121:3-121:45>
+
+
+Done.

--- a/testsuite/tests/name_resolution/generic_formal_types_defaults/test.yaml
+++ b/testsuite/tests/name_resolution/generic_formal_types_defaults/test.yaml
@@ -1,0 +1,2 @@
+driver: name-resolution
+input_sources: [set.adb]

--- a/testsuite/tests/parser/anonymous_type_no_aspects/test.out
+++ b/testsuite/tests/parser/anonymous_type_no_aspects/test.out
@@ -59,6 +59,7 @@ CompilationUnit[1:1-8:75]
 |  |  |  |  |  |  |  |f_name:
 |  |  |  |  |  |  |  |  Id[4:17-4:25]: unsigned
 |  |  |  |  |  |  |  |f_constraint: <null>
+|  |  |  |  |  |f_default_type: <null>
 |  |  |  |  |  |f_aspects: <null>
 |  |  |f_aspects:
 |  |  |  AspectSpec[5:3-8:74]

--- a/testsuite/tests/parser/basic_decl_0/test.out
+++ b/testsuite/tests/parser/basic_decl_0/test.out
@@ -10,4 +10,5 @@ TypeDecl[1:1-1:34]
 |  |  InterfaceKindTask[1:19-1:23]
 |  |f_interfaces:
 |  |  ParentList[1:23-1:23]: <empty list>
+|f_default_type: <null>
 |f_aspects: <null>

--- a/testsuite/tests/parser/basic_decl_12/test.out
+++ b/testsuite/tests/parser/basic_decl_12/test.out
@@ -49,6 +49,7 @@ SubpDecl[1:1-1:125]
 |  |  |  |  |  |  |  |  |  |  Id[1:64-1:69]: Class
 |  |  |  |  |  |  |  |  |  |f_args: <null>
 |  |  |  |  |  |  |  |  |f_constraint: <null>
+|  |  |  |  |  |  |f_default_type: <null>
 |  |  |  |  |  |  |f_aspects: <null>
 |  |  |  |  |f_default_expr: <null>
 |  |  |  |  |f_aspects: <null>

--- a/testsuite/tests/parser/basic_decl_4/test.out
+++ b/testsuite/tests/parser/basic_decl_4/test.out
@@ -69,6 +69,7 @@ SubpRenamingDecl[1:1-1:65]
 |  |  |  |  |  |  |  |  |f_name:
 |  |  |  |  |  |  |  |  |  Id[1:48-1:53]: Pouet
 |  |  |  |  |  |  |  |  |f_constraint: <null>
+|  |  |  |  |  |  |f_default_type: <null>
 |  |  |  |  |  |  |f_aspects: <null>
 |  |  |  |  |f_default_expr: <null>
 |  |  |  |  |f_aspects: <null>

--- a/testsuite/tests/parser/basic_decl_5/test.out
+++ b/testsuite/tests/parser/basic_decl_5/test.out
@@ -6,4 +6,5 @@ TypeDecl[1:1-1:16]
 |f_discriminants: <null>
 |f_type_def:
 |  FormalDiscreteTypeDef[1:11-1:15]
+|f_default_type: <null>
 |f_aspects: <null>

--- a/testsuite/tests/parser/basic_decl_6/test.out
+++ b/testsuite/tests/parser/basic_decl_6/test.out
@@ -10,4 +10,5 @@ TypeDecl[1:1-1:20]
 |  |  RangeSpec[1:11-1:19]
 |  |  |f_range:
 |  |  |  BoxExpr[1:17-1:19]
+|f_default_type: <null>
 |f_aspects: <null>

--- a/testsuite/tests/parser/basic_decl_7/test.out
+++ b/testsuite/tests/parser/basic_decl_7/test.out
@@ -8,4 +8,5 @@ TypeDecl[1:1-1:18]
 |  ModIntTypeDef[1:11-1:17]
 |  |f_expr:
 |  |  BoxExpr[1:15-1:17]
+|f_default_type: <null>
 |f_aspects: <null>

--- a/testsuite/tests/parser/basic_decl_8/test.out
+++ b/testsuite/tests/parser/basic_decl_8/test.out
@@ -9,4 +9,5 @@ TypeDecl[1:1-1:20]
 |  |f_delta:
 |  |  BoxExpr[1:17-1:19]
 |  |f_range: <null>
+|f_default_type: <null>
 |f_aspects: <null>

--- a/testsuite/tests/parser/basic_decl_9/test.out
+++ b/testsuite/tests/parser/basic_decl_9/test.out
@@ -11,4 +11,5 @@ TypeDecl[1:1-1:30]
 |  |f_digits:
 |  |  BoxExpr[1:27-1:29]
 |  |f_range: <null>
+|f_default_type: <null>
 |f_aspects: <null>

--- a/testsuite/tests/parser/enum_rep_clause_1/test.out
+++ b/testsuite/tests/parser/enum_rep_clause_1/test.out
@@ -31,6 +31,7 @@ CompilationUnit[1:1-4:14]
 |  |  |  |  |  |  |  |  |  DefiningName[2:18-2:21]
 |  |  |  |  |  |  |  |  |  |f_name:
 |  |  |  |  |  |  |  |  |  |  Id[2:18-2:21]: Red
+|  |  |  |  |  |f_default_type: <null>
 |  |  |  |  |  |f_aspects: <null>
 |  |  |  |  |  EnumRepClause[3:4-3:28]
 |  |  |  |  |  |f_type_name:

--- a/testsuite/tests/parser/full_type_decl_0/test.out
+++ b/testsuite/tests/parser/full_type_decl_0/test.out
@@ -23,4 +23,5 @@ TypeDecl[1:1-1:21]
 |  |  |  |  DefiningName[1:18-1:19]
 |  |  |  |  |f_name:
 |  |  |  |  |  Id[1:18-1:19]: D
+|f_default_type: <null>
 |f_aspects: <null>

--- a/testsuite/tests/parser/full_type_decl_1/test.out
+++ b/testsuite/tests/parser/full_type_decl_1/test.out
@@ -23,4 +23,5 @@ TypeDecl[1:1-1:27]
 |  |  |  |  DefiningName[1:22-1:25]
 |  |  |  |  |f_name:
 |  |  |  |  |  Chr[1:22-1:25]: 'D'
+|f_default_type: <null>
 |f_aspects: <null>

--- a/testsuite/tests/parser/full_type_decl_10/test.out
+++ b/testsuite/tests/parser/full_type_decl_10/test.out
@@ -28,4 +28,5 @@ TypeDecl[1:1-1:27]
 |  |f_record_extension: <null>
 |  |f_has_with_private:
 |  |  WithPrivateAbsent[1:26-1:26]
+|f_default_type: <null>
 |f_aspects: <null>

--- a/testsuite/tests/parser/full_type_decl_13/test.out
+++ b/testsuite/tests/parser/full_type_decl_13/test.out
@@ -12,4 +12,5 @@ TypeDecl[1:1-1:35]
 |  |  TaggedPresent[1:20-1:26]
 |  |f_has_limited:
 |  |  LimitedAbsent[1:26-1:26]
+|f_default_type: <null>
 |f_aspects: <null>

--- a/testsuite/tests/parser/full_type_decl_14/test.out
+++ b/testsuite/tests/parser/full_type_decl_14/test.out
@@ -8,4 +8,5 @@ TypeDecl[1:1-1:18]
 |  ModIntTypeDef[1:11-1:17]
 |  |f_expr:
 |  |  Int[1:15-1:17]: 12
+|f_default_type: <null>
 |f_aspects: <null>

--- a/testsuite/tests/parser/full_type_decl_15/test.out
+++ b/testsuite/tests/parser/full_type_decl_15/test.out
@@ -16,4 +16,5 @@ TypeDecl[1:1-1:25]
 |  |  |  |  OpDoubleDot[1:19-1:21]
 |  |  |  |f_right:
 |  |  |  |  Int[1:22-1:24]: 12
+|f_default_type: <null>
 |f_aspects: <null>

--- a/testsuite/tests/parser/full_type_decl_16/test.out
+++ b/testsuite/tests/parser/full_type_decl_16/test.out
@@ -31,4 +31,5 @@ TypeDecl[1:1-1:49]
 |  |  |  |f_name:
 |  |  |  |  Id[1:41-1:48]: Integer
 |  |  |  |f_constraint: <null>
+|f_default_type: <null>
 |f_aspects: <null>

--- a/testsuite/tests/parser/full_type_decl_17/test.out
+++ b/testsuite/tests/parser/full_type_decl_17/test.out
@@ -39,4 +39,5 @@ TypeDecl[1:1-1:51]
 |  |  |  |f_name:
 |  |  |  |  Id[1:43-1:50]: Integer
 |  |  |  |f_constraint: <null>
+|f_default_type: <null>
 |f_aspects: <null>

--- a/testsuite/tests/parser/full_type_decl_18/test.out
+++ b/testsuite/tests/parser/full_type_decl_18/test.out
@@ -30,4 +30,5 @@ TypeDecl[1:1-1:41]
 |  |  |  |f_name:
 |  |  |  |  Id[1:33-1:40]: Integer
 |  |  |  |f_constraint: <null>
+|f_default_type: <null>
 |f_aspects: <null>

--- a/testsuite/tests/parser/full_type_decl_19/test.out
+++ b/testsuite/tests/parser/full_type_decl_19/test.out
@@ -12,4 +12,5 @@ TypeDecl[1:1-1:52]
 |  |  ParentList[1:38-1:51]
 |  |  |  Id[1:38-1:42]: Ilol
 |  |  |  Id[1:47-1:51]: Imdr
+|f_default_type: <null>
 |f_aspects: <null>

--- a/testsuite/tests/parser/full_type_decl_2/test.out
+++ b/testsuite/tests/parser/full_type_decl_2/test.out
@@ -43,4 +43,5 @@ TypeDecl[1:1-1:47]
 |  |  |  |  |  |f_default_expr: <null>
 |  |  |  |  |  |f_aspects: <null>
 |  |  |  |f_variant_part: <null>
+|f_default_type: <null>
 |f_aspects: <null>

--- a/testsuite/tests/parser/full_type_decl_20/test.out
+++ b/testsuite/tests/parser/full_type_decl_20/test.out
@@ -9,4 +9,5 @@ TypeDecl[1:1-1:21]
 |  |f_interface_kind: <null>
 |  |f_interfaces:
 |  |  ParentList[1:10-1:10]: <empty list>
+|f_default_type: <null>
 |f_aspects: <null>

--- a/testsuite/tests/parser/full_type_decl_21/test.out
+++ b/testsuite/tests/parser/full_type_decl_21/test.out
@@ -19,4 +19,5 @@ TypeDecl[1:1-1:24]
 |  |  |f_name:
 |  |  |  Id[1:22-1:23]: B
 |  |  |f_constraint: <null>
+|f_default_type: <null>
 |f_aspects: <null>

--- a/testsuite/tests/parser/full_type_decl_22/test.out
+++ b/testsuite/tests/parser/full_type_decl_22/test.out
@@ -19,4 +19,5 @@ TypeDecl[1:1-1:31]
 |  |  |f_name:
 |  |  |  Id[1:29-1:30]: A
 |  |  |f_constraint: <null>
+|f_default_type: <null>
 |f_aspects: <null>

--- a/testsuite/tests/parser/full_type_decl_23/test.out
+++ b/testsuite/tests/parser/full_type_decl_23/test.out
@@ -9,4 +9,5 @@ TypeDecl[1:1-1:21]
 |  |f_interface_kind: <null>
 |  |f_interfaces:
 |  |  ParentList[1:10-1:10]: <empty list>
+|f_default_type: <null>
 |f_aspects: <null>

--- a/testsuite/tests/parser/full_type_decl_3/test.out
+++ b/testsuite/tests/parser/full_type_decl_3/test.out
@@ -60,4 +60,5 @@ TypeDecl[1:1-1:65]
 |  |  |  |  |  |f_default_expr: <null>
 |  |  |  |  |  |f_aspects: <null>
 |  |  |  |f_variant_part: <null>
+|f_default_type: <null>
 |f_aspects: <null>

--- a/testsuite/tests/parser/full_type_decl_4/test.out
+++ b/testsuite/tests/parser/full_type_decl_4/test.out
@@ -96,4 +96,5 @@ TypeDecl[1:1-1:118]
 |  |  |  |  |  |  |  |  |  |f_default_expr: <null>
 |  |  |  |  |  |  |  |  |  |f_aspects: <null>
 |  |  |  |  |  |  |  |f_variant_part: <null>
+|f_default_type: <null>
 |f_aspects: <null>

--- a/testsuite/tests/parser/full_type_decl_5/test.out
+++ b/testsuite/tests/parser/full_type_decl_5/test.out
@@ -20,4 +20,5 @@ TypeDecl[1:1-1:69]
 |  |  |  |  OpDoubleDot[1:61-1:63]
 |  |  |  |f_right:
 |  |  |  |  Id[1:64-1:68]: High
+|f_default_type: <null>
 |f_aspects: <null>

--- a/testsuite/tests/parser/full_type_decl_6/test.out
+++ b/testsuite/tests/parser/full_type_decl_6/test.out
@@ -54,4 +54,5 @@ TypeDecl[1:1-1:58]
 |  |  |  |f_variant_part: <null>
 |  |f_has_with_private:
 |  |  WithPrivateAbsent[1:57-1:57]
+|f_default_type: <null>
 |f_aspects: <null>

--- a/testsuite/tests/parser/full_type_decl_7/test.out
+++ b/testsuite/tests/parser/full_type_decl_7/test.out
@@ -63,4 +63,5 @@ TypeDecl[1:1-1:81]
 |  |  |  |  |  |f_default_expr: <null>
 |  |  |  |  |  |f_aspects: <null>
 |  |  |  |f_variant_part: <null>
+|f_default_type: <null>
 |f_aspects: <null>

--- a/testsuite/tests/parser/full_type_decl_8/test.out
+++ b/testsuite/tests/parser/full_type_decl_8/test.out
@@ -61,4 +61,5 @@ TypeDecl[1:1-1:79]
 |  |  |  |f_variant_part: <null>
 |  |f_has_with_private:
 |  |  WithPrivateAbsent[1:78-1:78]
+|f_default_type: <null>
 |f_aspects: <null>

--- a/testsuite/tests/parser/full_type_decl_9/test.out
+++ b/testsuite/tests/parser/full_type_decl_9/test.out
@@ -32,4 +32,5 @@ TypeDecl[1:1-1:50]
 |  |  |  |  OpDoubleDot[1:41-1:43]
 |  |  |  |f_right:
 |  |  |  |  Real[1:44-1:49]: 360.0
+|f_default_type: <null>
 |f_aspects: <null>

--- a/testsuite/tests/parser/generic_declaration_0/test.out
+++ b/testsuite/tests/parser/generic_declaration_0/test.out
@@ -19,6 +19,7 @@ GenericSubpDecl[1:1-1:77]
 |  |  |  |  |  |  TaggedAbsent[1:26-1:26]
 |  |  |  |  |  |f_has_limited:
 |  |  |  |  |  |  LimitedAbsent[1:26-1:26]
+|  |  |  |  |f_default_type: <null>
 |  |  |  |  |f_aspects: <null>
 |f_subp_decl:
 |  GenericSubpInternal[1:36-1:76]

--- a/testsuite/tests/parser/generic_declaration_1/test.out
+++ b/testsuite/tests/parser/generic_declaration_1/test.out
@@ -43,6 +43,7 @@ GenericPackageDecl[1:1-7:19]
 |  |  |  |  |  |  TaggedAbsent[3:22-3:22]
 |  |  |  |  |  |f_has_limited:
 |  |  |  |  |  |  LimitedAbsent[3:22-3:22]
+|  |  |  |  |f_default_type: <null>
 |  |  |  |  |f_aspects: <null>
 |f_package_decl:
 |  GenericPackageInternal[4:1-7:19]

--- a/testsuite/tests/parser/generic_enum/test.out
+++ b/testsuite/tests/parser/generic_enum/test.out
@@ -69,6 +69,7 @@ CompilationUnit[1:1-24:10]
 |  |  |  |  |  |  |  |  |  DefiningName[4:26-4:27]
 |  |  |  |  |  |  |  |  |  |f_name:
 |  |  |  |  |  |  |  |  |  |  Id[4:26-4:27]: C
+|  |  |  |  |  |f_default_type: <null>
 |  |  |  |  |  |f_aspects: <null>
 |  |  |  |  |  GenericPackageDecl[5:4-10:10]
 |  |  |  |  |  |f_formal_part:

--- a/testsuite/tests/parser/object_decl_0/test.out
+++ b/testsuite/tests/parser/object_decl_0/test.out
@@ -34,6 +34,7 @@ ObjectDecl[1:1-1:49]
 |  |  |  |  |f_name:
 |  |  |  |  |  Id[1:33-1:40]: Integer
 |  |  |  |  |f_constraint: <null>
+|  |  |f_default_type: <null>
 |  |  |f_aspects: <null>
 |f_default_expr:
 |  Null[1:44-1:48]: null

--- a/testsuite/tests/parser/object_decl_1/test.out
+++ b/testsuite/tests/parser/object_decl_1/test.out
@@ -34,6 +34,7 @@ ObjectDecl[1:1-1:65]
 |  |  |  |  |f_name:
 |  |  |  |  |  Id[1:33-1:40]: Integer
 |  |  |  |  |f_constraint: <null>
+|  |  |f_default_type: <null>
 |  |  |f_aspects: <null>
 |f_default_expr:
 |  Null[1:44-1:48]: null

--- a/testsuite/tests/parser/object_decl_2/test.out
+++ b/testsuite/tests/parser/object_decl_2/test.out
@@ -42,6 +42,7 @@ ObjectDecl[1:1-1:51]
 |  |  |  |  |  |f_name:
 |  |  |  |  |  |  Id[1:43-1:50]: Integer
 |  |  |  |  |  |f_constraint: <null>
+|  |  |f_default_type: <null>
 |  |  |f_aspects: <null>
 |f_default_expr: <null>
 |f_renaming_clause: <null>

--- a/testsuite/tests/parser/package_decl_1/test.out
+++ b/testsuite/tests/parser/package_decl_1/test.out
@@ -88,6 +88,7 @@ PackageDecl[1:1-1:106]
 |  |  |  |  |  |  |  |f_name:
 |  |  |  |  |  |  |  |  Id[1:84-1:90]: Double
 |  |  |  |  |  |  |  |f_constraint: <null>
+|  |  |  |  |  |f_default_type: <null>
 |  |  |  |  |  |f_aspects: <null>
 |  |  |  |f_default_expr:
 |  |  |  |  Null[1:94-1:98]: null

--- a/testsuite/tests/parser/subprogram_spec_1/test.out
+++ b/testsuite/tests/parser/subprogram_spec_1/test.out
@@ -65,6 +65,7 @@ SubpSpec[1:1-1:65]
 |  |  |  |  |  |  |  |f_name:
 |  |  |  |  |  |  |  |  Id[1:42-1:49]: Integer
 |  |  |  |  |  |  |  |f_constraint: <null>
+|  |  |  |  |  |f_default_type: <null>
 |  |  |  |  |  |f_aspects: <null>
 |  |  |  |f_default_expr: <null>
 |  |  |  |f_aspects: <null>

--- a/testsuite/tests/parser/subprogram_spec_3/test.out
+++ b/testsuite/tests/parser/subprogram_spec_3/test.out
@@ -61,6 +61,7 @@ SubpSpec[1:1-1:69]
 |  |  |  |  |  |  |  |  |  |  |f_aspects: <null>
 |  |  |  |  |  |  |  |f_subp_returns: <null>
 |  |  |  |  |  |  |f_aspects: <null>
+|  |  |  |  |  |f_default_type: <null>
 |  |  |  |  |  |f_aspects: <null>
 |  |  |  |f_default_expr: <null>
 |  |  |  |f_aspects: <null>

--- a/testsuite/tests/parser/task_body_0/test.out
+++ b/testsuite/tests/parser/task_body_0/test.out
@@ -143,6 +143,7 @@ TaskBody[1:1-24:29]
 |  |  |  |  |  |  |  |  |f_name:
 |  |  |  |  |  |  |  |  |  Id[6:30-6:34]: Item
 |  |  |  |  |  |  |  |  |f_constraint: <null>
+|  |  |  |  |  |f_default_type: <null>
 |  |  |  |  |  |f_aspects: <null>
 |  |  |  |f_default_expr: <null>
 |  |  |  |f_renaming_clause: <null>

--- a/testsuite/tests/parser/type_decl_0/test.out
+++ b/testsuite/tests/parser/type_decl_0/test.out
@@ -257,4 +257,5 @@ TypeDecl[1:1-18:12]
 |  |  |  |  |  |  |  |  AdaNodeList[16:29-16:34]
 |  |  |  |  |  |  |  |  |  NullComponentDecl[16:29-16:34]
 |  |  |  |  |  |  |  |f_variant_part: <null>
+|f_default_type: <null>
 |f_aspects: <null>

--- a/testsuite/tests/parser/type_decl_1/test.out
+++ b/testsuite/tests/parser/type_decl_1/test.out
@@ -19,4 +19,5 @@ TypeDecl[1:1-1:23]
 |  |  |  |f_components:
 |  |  |  |  AdaNodeList[1:22-1:22]: <empty list>
 |  |  |  |f_variant_part: <null>
+|f_default_type: <null>
 |f_aspects: <null>

--- a/user_manual/changes/V104-012.yaml
+++ b/user_manual/changes/V104-012.yaml
@@ -1,0 +1,6 @@
+type: new-feature
+title: Defaults for generic formal types (Ada 2022)
+description: |
+    Allow default subtypes to be specified in generic formal type
+    parameters.
+date: 2022-01-04


### PR DESCRIPTION
This patch adds support for default subtypes to be specified in
generic formal type parameters.

See also:
http://www.ada-auth.org/cgi-bin/cvsweb.cgi/ai12s/ai12-0205-1.txt.

TN: V104-012