### PR TITLE
Fix ``is_constant_object`` property

### DIFF
--- a/ada/ast.py
+++ b/ada/ast.py
@@ -16414,6 +16414,8 @@ class BaseSubpBody(Body):
 
     defining_names = Property(Entity.subp_spec.name.singleton)
 
+    is_constant_object = Property(True)
+
     @langkit_property(return_type=LexicalEnv, dynamic_vars=[origin])
     def defining_env():
         return If(

--- a/testsuite/tests/properties/is_constant_object/pack.adb
+++ b/testsuite/tests/properties/is_constant_object/pack.adb
@@ -1,0 +1,9 @@
+package body Pack is
+   function My_Fun (I : Integer) return Integer is
+   begin
+      return I + 1;
+   end;
+
+   My_2 : Integer renames My_Fun (1);
+   --% node.p_is_constant_object
+end Pack;

--- a/testsuite/tests/properties/is_constant_object/pack.ads
+++ b/testsuite/tests/properties/is_constant_object/pack.ads
@@ -1,0 +1,2 @@
+package Pack is
+end Pack;

--- a/testsuite/tests/properties/is_constant_object/test.out
+++ b/testsuite/tests/properties/is_constant_object/test.out
@@ -96,6 +96,10 @@ Eval 'node.find(lal.ForLoopVarDecl).p_is_constant_object' on node <ForLoopStmt l
 Result: True
 
 
+Eval 'node.p_is_constant_object' on node <ObjectDecl ["My_2"] pack.adb:7:4-7:38>
+Result: True
+
+
 Eval 'node.f_return_expr.p_is_constant' on node <ReturnStmt protect.adb:10:10-10:19>
 Result: True
 

--- a/testsuite/tests/properties/is_constant_object/test.yaml
+++ b/testsuite/tests/properties/is_constant_object/test.yaml
@@ -2,4 +2,4 @@ driver: inline-playground
 input_sources: [constant.ads, constant.adb, renam.ads, renam.adb,
                 discr.adb, accessconst.adb, loops.adb, choice.adb,
                 index.ads, ers.adb, qual.adb, protect.ads,
-                protect.adb, view.adb]
+                protect.adb, view.adb, pack.adb]


### PR DESCRIPTION
This fix adds a missing case for the ``is_constant_object`` property
where a call expression refers to a subprogram without specification.

TN: V107-027