### PR TITLE
Add tests for aspect specifications on formal parameters

### DIFF
--- a/testsuite/tests/properties/get_has_aspect_param_spec/aspec.adb
+++ b/testsuite/tests/properties/get_has_aspect_param_spec/aspec.adb
@@ -1,0 +1,10 @@
+procedure Aspec is
+   function Foo (X : Natural; Y : Natural with Unreferenced)
+      return Natural is (2 * X);
+   --% node.find(lal.ParamSpecList)[1].p_has_aspect('Fail')
+   --% node.find(lal.ParamSpecList)[1].p_has_aspect('Unreferenced')
+   --% node.find(lal.ParamSpecList)[1].p_get_aspect('Fail')
+   --% node.find(lal.ParamSpecList)[1].p_get_aspect('Unreferenced')
+begin
+   null;
+end Aspec;

--- a/testsuite/tests/properties/get_has_aspect_param_spec/test.out
+++ b/testsuite/tests/properties/get_has_aspect_param_spec/test.out
@@ -1,0 +1,13 @@
+Eval 'node.find(lal.ParamSpecList)[1].p_has_aspect('Fail')' on node <ExprFunction ["Foo"] aspec.adb:2:4-3:33>
+Result: False
+
+Eval 'node.find(lal.ParamSpecList)[1].p_has_aspect('Unreferenced')' on node <ExprFunction ["Foo"] aspec.adb:2:4-3:33>
+Result: True
+
+Eval 'node.find(lal.ParamSpecList)[1].p_get_aspect('Fail')' on node <ExprFunction ["Foo"] aspec.adb:2:4-3:33>
+Result: <Aspect exists=False node=None value=None>
+
+Eval 'node.find(lal.ParamSpecList)[1].p_get_aspect('Unreferenced')' on node <ExprFunction ["Foo"] aspec.adb:2:4-3:33>
+Result: <Aspect exists=True node=<AspectAssoc aspec.adb:2:48-2:60> value=None>
+
+

--- a/testsuite/tests/properties/get_has_aspect_param_spec/test.yaml
+++ b/testsuite/tests/properties/get_has_aspect_param_spec/test.yaml
@@ -1,0 +1,2 @@
+driver: inline-playground
+input_sources: [aspec.adb]


### PR DESCRIPTION
This patch just adds some tests for the Ada 2022 feature allowing
aspect specifications on formal parameters.

See: http://www.ada-auth.org/cgi-bin/cvsweb.cgi/ai12s/ai12-0395-1.txt.

TN: V112-031