### PR TITLE
Most declarations allows aspect specifications

### DIFF
--- a/ada/ast.py
+++ b/ada/ast.py
@@ -3623,7 +3623,7 @@ class DiscriminantSpec(BaseFormalParamDecl):
     ids = Field(type=T.DefiningName.list)
     type_expr = Field(type=T.TypeExpr)
     default_expr = Field(type=T.Expr)
-    aspects = NullField()
+    aspects = Field(type=T.AspectSpec)
 
     env_spec = EnvSpec(add_to_env(Self.env_mappings(Self.ids, Self)))
 
@@ -17609,7 +17609,7 @@ class EntryIndexSpec(BasicDecl):
 
     id = Field(type=T.DefiningName)
     subtype = Field(type=T.AdaNode)
-    aspects = NullField()
+    aspects = Field(type=T.AspectSpec)
 
     env_spec = EnvSpec(add_to_env_kv(Entity.name_symbol, Self))
 

--- a/ada/grammar.py
+++ b/ada/grammar.py
@@ -227,7 +227,7 @@ A.add_rules(
 
     discriminant_spec=DiscriminantSpec(
         List(A.defining_id, sep=","), ":", A.type_expr,
-        Opt(":=", A.expr)
+        Opt(":=", A.expr), Opt(A.aspect_spec)
     ),
 
     discr_spec_list=List(A.discriminant_spec, sep=";"),
@@ -805,7 +805,8 @@ A.add_rules(
     entry_body=EntryBody(
         "entry", A.defining_id,
         Opt(EntryIndexSpec("(", "for", A.defining_id, "in",
-                           A.discrete_subtype_definition, ")")),
+                           A.discrete_subtype_definition,
+                           Opt(A.aspect_spec), ")")),
         EntryCompletionFormalParams(Opt(A.param_specs)),
         A.aspect_spec,
         "when", A.expr,

--- a/testsuite/tests/lexical_envs/records/test.out
+++ b/testsuite/tests/lexical_envs/records/test.out
@@ -106,6 +106,7 @@ CompilationUnit[1:1-11:9]
 |  |  |  |  |  |  |  |  |  |  Id[7:22-7:29]: Natural
 |  |  |  |  |  |  |  |  |  |f_constraint: <null>
 |  |  |  |  |  |  |  |  |f_default_expr: <null>
+|  |  |  |  |  |  |  |  |f_aspects: <null>
 |  |  |  |  |  |f_type_def:
 |  |  |  |  |  |  RecordTypeDef[7:34-10:14]
 |  |  |  |  |  |  |f_has_abstract:

--- a/testsuite/tests/parser/discriminant_part_1/test.out
+++ b/testsuite/tests/parser/discriminant_part_1/test.out
@@ -15,6 +15,7 @@ KnownDiscriminantPart[1:1-1:26]
 |  |  |  |  Id[1:6-1:13]: Integer
 |  |  |  |f_constraint: <null>
 |  |  |f_default_expr: <null>
+|  |  |f_aspects: <null>
 |  |  DiscriminantSpec[1:15-1:25]
 |  |  |f_ids:
 |  |  |  DefiningNameList[1:15-1:16]
@@ -29,3 +30,4 @@ KnownDiscriminantPart[1:1-1:26]
 |  |  |  |  Id[1:19-1:25]: String
 |  |  |  |f_constraint: <null>
 |  |  |f_default_expr: <null>
+|  |  |f_aspects: <null>

--- a/testsuite/tests/parser/full_type_decl_3/test.out
+++ b/testsuite/tests/parser/full_type_decl_3/test.out
@@ -21,6 +21,7 @@ TypeDecl[1:1-1:65]
 |  |  |  |  |  Id[1:19-1:26]: Integer
 |  |  |  |  |f_constraint: <null>
 |  |  |  |f_default_expr: <null>
+|  |  |  |f_aspects: <null>
 |f_type_def:
 |  RecordTypeDef[1:31-1:64]
 |  |f_has_abstract:

--- a/testsuite/tests/parser/full_type_decl_4/test.out
+++ b/testsuite/tests/parser/full_type_decl_4/test.out
@@ -21,6 +21,7 @@ TypeDecl[1:1-1:118]
 |  |  |  |  |  Id[1:19-1:26]: Integer
 |  |  |  |  |f_constraint: <null>
 |  |  |  |f_default_expr: <null>
+|  |  |  |f_aspects: <null>
 |f_type_def:
 |  RecordTypeDef[1:31-1:117]
 |  |f_has_abstract:

--- a/testsuite/tests/parser/full_type_decl_7/test.out
+++ b/testsuite/tests/parser/full_type_decl_7/test.out
@@ -24,6 +24,7 @@ TypeDecl[1:1-1:81]
 |  |  |  |  |  Id[1:28-1:35]: Integer
 |  |  |  |  |f_constraint: <null>
 |  |  |  |f_default_expr: <null>
+|  |  |  |f_aspects: <null>
 |f_type_def:
 |  RecordTypeDef[1:40-1:80]
 |  |f_has_abstract:

--- a/testsuite/tests/parser/type_decl_0/test.out
+++ b/testsuite/tests/parser/type_decl_0/test.out
@@ -22,6 +22,7 @@ TypeDecl[1:1-18:12]
 |  |  |  |  |f_constraint: <null>
 |  |  |  |f_default_expr:
 |  |  |  |  Int[1:24-1:25]: 8
+|  |  |  |f_aspects: <null>
 |f_type_def:
 |  RecordTypeDef[1:31-18:11]
 |  |f_has_abstract:

--- a/testsuite/tests/properties/aspect_spec_most_decls/aspec.adb
+++ b/testsuite/tests/properties/aspect_spec_most_decls/aspec.adb
@@ -1,0 +1,35 @@
+procedure Aspec is
+   type Items_Array is array (Positive range <>) of Integer;
+
+   type R (D : Integer with XXX) is
+   record
+      Items : Items_Array (1 .. D);
+   end record;
+   --% node.find(lal.DiscriminantSpec).p_has_aspect('XXX')
+   --% node.find(lal.DiscriminantSpec).p_get_aspect('XXX')
+
+   function Func1 return String is
+   begin
+        return Result : String (1..0) with XXX;
+   end Func1;
+   --% node.find(lal.ExtendedReturnStmtObjectDecl).p_has_aspect('XXX')
+   --% node.find(lal.ExtendedReturnStmtObjectDecl).p_get_aspect('XXX')
+
+   protected P is
+   private
+      entry E1 (Boolean) (N : Natural);
+   end P;
+
+   protected body P is
+      entry E1 (for B in Boolean with XXX)
+      (N : Natural) when True is
+      begin
+        null;
+      end E1;
+   end P;
+   --% node.find(lal.EntryIndexSpec).p_has_aspect('XXX')
+   --% node.find(lal.EntryIndexSpec).p_get_aspect('XXX')
+
+begin
+   null;
+end Aspec;

--- a/testsuite/tests/properties/aspect_spec_most_decls/test.out
+++ b/testsuite/tests/properties/aspect_spec_most_decls/test.out
@@ -1,0 +1,19 @@
+Eval 'node.find(lal.DiscriminantSpec).p_has_aspect('XXX')' on node <TypeDecl ["R"] aspec.adb:4:4-7:15>
+Result: True
+
+Eval 'node.find(lal.DiscriminantSpec).p_get_aspect('XXX')' on node <TypeDecl ["R"] aspec.adb:4:4-7:15>
+Result: <Aspect exists=True node=<AspectAssoc aspec.adb:4:29-4:32> value=None>
+
+Eval 'node.find(lal.ExtendedReturnStmtObjectDecl).p_has_aspect('XXX')' on node <SubpBody ["Func1"] aspec.adb:11:4-14:14>
+Result: True
+
+Eval 'node.find(lal.ExtendedReturnStmtObjectDecl).p_get_aspect('XXX')' on node <SubpBody ["Func1"] aspec.adb:11:4-14:14>
+Result: <Aspect exists=True node=<AspectAssoc aspec.adb:13:44-13:47> value=None>
+
+Eval 'node.find(lal.EntryIndexSpec).p_has_aspect('XXX')' on node <ProtectedBody ["P"] aspec.adb:23:4-29:10>
+Result: True
+
+Eval 'node.find(lal.EntryIndexSpec).p_get_aspect('XXX')' on node <ProtectedBody ["P"] aspec.adb:23:4-29:10>
+Result: <Aspect exists=True node=<AspectAssoc aspec.adb:24:39-24:42> value=None>
+
+

--- a/testsuite/tests/properties/aspect_spec_most_decls/test.yaml
+++ b/testsuite/tests/properties/aspect_spec_most_decls/test.yaml
@@ -1,0 +1,2 @@
+driver: inline-playground
+input_sources: [aspec.adb]

--- a/user_manual/changes/V112-052.yaml
+++ b/user_manual/changes/V112-052.yaml
@@ -1,0 +1,7 @@
+type: new-feature
+title: Most declarations allows aspect specifications
+description: |
+    As stated by the 2022 Ada standard revision, this new feature allows aspect
+    specifications on most declarations. It concerns extended return object
+    declarations, discriminant specifications, and entry index specifications.
+date: 2022-01-12


### PR DESCRIPTION
As stated by the 2022 Ada standard revision, this new feature allows
aspect specifications on most declarations. It concerns extended
return object declarations, discriminant specifications, and entry
index specifications.

See: http://www.ada-auth.org/cgi-bin/cvsweb.cgi/ai12s/ai12-0398-1.txt.

TN: V112-052