### PR TITLE
Allow access definition in loop parameter subtype indication

### DIFF
--- a/ada/ast.py
+++ b/ada/ast.py
@@ -14869,7 +14869,7 @@ class ForLoopVarDecl(BasicDecl):
     """
 
     id = Field(type=T.DefiningName)
-    id_type = Field(type=T.SubtypeIndication)
+    id_type = Field(type=T.TypeExpr)
     aspects = NullField()
 
     defining_names = Property(Entity.id.singleton)

--- a/ada/grammar.py
+++ b/ada/grammar.py
@@ -1060,7 +1060,7 @@ A.add_rules(
     ),
 
     for_loop_param_spec=ForLoopSpec(
-        ForLoopVarDecl(A.defining_id, Opt(":", A.subtype_indication)),
+        ForLoopVarDecl(A.defining_id, Opt(":", A.type_expr)),
         IterType.alt_in("in") | IterType.alt_of("of"),
         Reverse("reverse"),
         A.discrete_range | A.discrete_subtype_indication | A.name,

--- a/testsuite/tests/name_resolution/access_def_subtype_indication/iter.adb
+++ b/testsuite/tests/name_resolution/access_def_subtype_indication/iter.adb
@@ -1,0 +1,9 @@
+procedure Iter is
+   type Vec is array (1..10) of access Integer;
+   X : Vec := (others => new Integer'(1));
+begin
+   for Ref : access Integer of X loop
+      Ref.all := Ref.all + 1;
+   end loop;
+   pragma Test_Block;
+end Iter;

--- a/testsuite/tests/name_resolution/access_def_subtype_indication/test.out
+++ b/testsuite/tests/name_resolution/access_def_subtype_indication/test.out
@@ -1,0 +1,39 @@
+Analyzing iter.adb
+##################
+
+Resolving xrefs for node <ForLoopSpec iter.adb:5:8-5:33>
+********************************************************
+
+Expr: <Id "Integer" iter.adb:5:21-5:28>
+  references: None
+  type:       None
+Expr: <Id "X" iter.adb:5:32-5:33>
+  references: <DefiningName iter.adb:3:4-3:5>
+  type:       <TypeDecl ["Vec"] iter.adb:2:4-2:48>
+
+Resolving xrefs for node <AssignStmt iter.adb:6:7-6:30>
+*******************************************************
+
+Expr: <ExplicitDeref iter.adb:6:7-6:14>
+  references: <DefiningName iter.adb:5:8-5:11>
+  type:       <TypeDecl ["Integer"] __standard:4:3-4:54>
+Expr: <Id "Ref" iter.adb:6:7-6:10>
+  references: <DefiningName iter.adb:5:8-5:11>
+  type:       <AnonymousTypeDecl ["None"] iter.adb:5:14-5:28>
+Expr: <BinOp iter.adb:6:18-6:29>
+  type:       <TypeDecl ["Integer"] __standard:4:3-4:54>
+Expr: <ExplicitDeref iter.adb:6:18-6:25>
+  references: <DefiningName iter.adb:5:8-5:11>
+  type:       <TypeDecl ["Integer"] __standard:4:3-4:54>
+Expr: <Id "Ref" iter.adb:6:18-6:21>
+  references: <DefiningName iter.adb:5:8-5:11>
+  type:       <AnonymousTypeDecl ["None"] iter.adb:5:14-5:28>
+Expr: <OpPlus "+" iter.adb:6:26-6:27>
+  references: None
+  type:       None
+Expr: <Int iter.adb:6:28-6:29>
+  references: None
+  type:       <TypeDecl ["Universal_Int_Type_"] __standard:121:3-121:45>
+
+
+Done.

--- a/testsuite/tests/name_resolution/access_def_subtype_indication/test.yaml
+++ b/testsuite/tests/name_resolution/access_def_subtype_indication/test.yaml
@@ -1,0 +1,2 @@
+driver: name-resolution
+input_sources: [iter.adb]

--- a/user_manual/changes/V104-011.yaml
+++ b/user_manual/changes/V104-011.yaml
@@ -1,0 +1,6 @@
+type: new-feature
+title: Access definition for loop param subtype indication
+description: |
+    As stated by the 2022 Ada standard revision, this new feature adds support
+    for access definition in loop parameter subtype indication.
+date: 2022-01-18


### PR DESCRIPTION
This patch adds support for access definition in loop parameter
subtype indication, as part of the Ada 2022 feature defined by
AI12-0156
(http://www.ada-auth.org/cgi-bin/cvsweb.cgi/ai12s/ai12-0156-1.txt).

TN: V104-011