### PR TITLE
V106-029: Compare the canonical representations of types.

### DIFF
--- a/ada/ast.py
+++ b/ada/ast.py
@@ -5755,6 +5755,19 @@ class BaseTypeDecl(BasicDecl):
         )
 
     @langkit_property(return_type=Bool)
+    def has_base_type_impl(target=T.BaseTypeDecl):
+        """
+        Implementation of `has_base_type`, which assumes that `target` has
+        been canonicalized.
+        """
+        return Or(
+            Entity.canonical_type.node == target,
+            Entity.base_types.any(
+                lambda bt: bt.has_base_type(target)
+            )
+        )
+
+    @langkit_property(return_type=Bool)
     def has_base_type(target=T.BaseTypeDecl):
         """
         Return whether the given type is amongst the bases types (direct or
@@ -5764,11 +5777,8 @@ class BaseTypeDecl(BasicDecl):
             rebindings of `target`, meaning any instance of `target` will be
             accepted.
         """
-        return Or(
-            Self == target,
-            Entity.base_types.any(
-                lambda bt: bt.has_base_type(target)
-            )
+        return Entity.has_base_type_impl(
+            target.as_bare_entity.canonical_type.node
         )
 
 

--- a/testsuite/tests/properties/inherited_primitives_2/pkg-der.adb
+++ b/testsuite/tests/properties/inherited_primitives_2/pkg-der.adb
@@ -1,0 +1,9 @@
+package body Pkg.Der is
+   procedure Foo (X : U) is null;
+
+   type D is new T with null record;
+   --% node.p_get_primitives()
+
+   procedure Foo (X : D);
+   procedure Foo (X : D) is null;
+end Pkg.Der;

--- a/testsuite/tests/properties/inherited_primitives_2/pkg-der.ads
+++ b/testsuite/tests/properties/inherited_primitives_2/pkg-der.ads
@@ -1,0 +1,13 @@
+package Pkg.Der is
+   type U is tagged private;
+   --% node.p_get_primitives()
+
+   procedure Bar (X : U);
+   procedure Foo (X : U);
+
+private
+   type U is new T with null record;
+   --% node.p_get_primitives()
+
+   procedure Bar (X : U) is null;
+end Pkg.Der;

--- a/testsuite/tests/properties/inherited_primitives_2/pkg.adb
+++ b/testsuite/tests/properties/inherited_primitives_2/pkg.adb
@@ -1,0 +1,3 @@
+package body Pkg is
+   function Priv (X : T) return Integer is (2);
+end Pkg;

--- a/testsuite/tests/properties/inherited_primitives_2/pkg.ads
+++ b/testsuite/tests/properties/inherited_primitives_2/pkg.ads
@@ -1,0 +1,12 @@
+package Pkg is
+   type T is abstract tagged private;
+   --% node.p_get_primitives()
+
+   procedure Foo (X : T) is abstract;
+
+private
+   type T is abstract tagged null record;
+   --% node.p_get_primitives()
+
+   function Priv (X : T) return Integer;
+end Pkg;

--- a/testsuite/tests/properties/inherited_primitives_2/test.out
+++ b/testsuite/tests/properties/inherited_primitives_2/test.out
@@ -1,0 +1,19 @@
+Eval 'node.p_get_primitives()' on node <TypeDecl ["D"] pkg-der.adb:4:4-4:37>
+Result: [<SubpDecl ["Priv"] pkg.ads:11:4-11:41>, <SubpDecl ["Foo"] pkg-der.adb:7:4-7:26>, <NullSubpDecl ["Foo"] pkg-der.adb:8:4-8:34>]
+
+
+Eval 'node.p_get_primitives()' on node <TypeDecl ["U"] pkg-der.ads:2:4-2:29>
+Result: [<SubpDecl ["Bar"] pkg-der.ads:5:4-5:26>, <SubpDecl ["Foo"] pkg-der.ads:6:4-6:26>, <NullSubpDecl ["Bar"] pkg-der.ads:12:4-12:34>]
+
+Eval 'node.p_get_primitives()' on node <TypeDecl ["U"] pkg-der.ads:9:4-9:37>
+Result: [<SubpDecl ["Priv"] pkg.ads:11:4-11:41>, <SubpDecl ["Bar"] pkg-der.ads:5:4-5:26>, <NullSubpDecl ["Bar"] pkg-der.ads:12:4-12:34>]
+
+
+
+Eval 'node.p_get_primitives()' on node <TypeDecl ["T"] pkg.ads:2:4-2:38>
+Result: [<AbstractSubpDecl ["Foo"] pkg.ads:5:4-5:38>, <SubpDecl ["Priv"] pkg.ads:11:4-11:41>]
+
+Eval 'node.p_get_primitives()' on node <TypeDecl ["T"] pkg.ads:8:4-8:42>
+Result: [<AbstractSubpDecl ["Foo"] pkg.ads:5:4-5:38>, <SubpDecl ["Priv"] pkg.ads:11:4-11:41>]
+
+

--- a/testsuite/tests/properties/inherited_primitives_2/test.yaml
+++ b/testsuite/tests/properties/inherited_primitives_2/test.yaml
@@ -1,0 +1,2 @@
+driver: inline-playground
+input_sources: [pkg.ads, pkg.adb, pkg-der.ads, pkg-der.adb]


### PR DESCRIPTION
This fixes a regression introduced by the previous change on this ticket. I added a regression test for that.