### PR TITLE
Add a new property to query the kind of a CallExpr

### DIFF
--- a/ada/ast.py
+++ b/ada/ast.py
@@ -11940,6 +11940,21 @@ class TargetName(Name):
         )
 
 
+class CallExprKind(Enum):
+    """
+    Kind of CallExpr type.
+
+    - ``call`` is when the CallExpr is a procedure or function call.
+    - ``array_slice``, ``array_index`` is when the CallExpr is in fact an
+      array slice or an array subcomponent access expression, respectively.
+    - ``type_conversion`` is when the CallExpr is a type conversion.
+    """
+    call = EnumValue()
+    array_slice = EnumValue()
+    array_index = EnumValue()
+    type_conversion = EnumValue()
+
+
 class CallExpr(Name):
     """
     Represent a syntactic call expression.
@@ -11959,15 +11974,41 @@ class CallExpr(Name):
 
     relative_name = Property(Entity.name.relative_name)
 
-    @langkit_property()
-    def is_constant():
+    @langkit_property(public=True)
+    def kind():
+        """
+        Return whether this expression is a subprogram call, an array
+        subcomponent access expression, an array slice or a type conversion.
+        """
         return Cond(
+            Entity.is_call,
+            CallExprKind.call,
+
+            Entity.is_array_slice,
+            CallExprKind.array_slice,
+
+            origin.bind(
+                Self.origin_node,
+                Not(Entity.name.expression_type.array_def_with_deref.is_null)
+            ),
+            CallExprKind.array_index,
+
             # Case for type conversion: CallExpr has one
             # argument and its name denotes a type declaration.
             And(
                 Entity.params.length == 1,
                 Entity.name.referenced_decl.is_a(T.TypeDecl)
             ),
+            CallExprKind.type_conversion,
+
+            # Should not happen
+            PropertyError(CallExprKind, "undetermined CallExpr kind")
+        )
+
+    @langkit_property()
+    def is_constant():
+        return Cond(
+            Entity.kind == CallExprKind.type_conversion,
             Entity.params.at(0).expr.match(
                 # View conversion: constant if the object is constant (value
                 # conversion is always constant).

--- a/testsuite/tests/properties/call_expr_kind/kind.adb
+++ b/testsuite/tests/properties/call_expr_kind/kind.adb
@@ -1,0 +1,48 @@
+procedure Kind is
+   package P is
+      type T is tagged null record;
+      type T2 is new T with record
+         A, B : Integer;
+      end record;
+   end P;
+
+   V : P.T'Class := P.T2'(1, 2);
+   V2 : P.T'Class := V;
+   V3 : P.T'Class := V;
+
+   type A is array (Natural range <>) of Integer;
+   E : A (1 .. 4) := (1, 2, 3, 4);
+   G : A (1 .. 2);
+
+   Q : Integer;
+
+   procedure P1 (A : Integer) is
+   begin
+      null;
+   end P1;
+
+   function F1 (A : Integer) return Boolean is
+   begin
+      P1 (A);
+      --% node.f_call.p_kind
+      return True;
+   end F1;
+
+   Y : Boolean;
+begin
+   P.T2 (V3).A := P.T2 (V2).A;
+   --% node.f_dest.f_prefix.p_kind
+   --% node.f_expr.f_prefix.p_kind
+
+   Q := Integer (2.5);
+   --% node.f_expr.p_kind
+
+   Q := E(1);
+   --% node.f_expr.p_kind
+
+   G := E(1 .. 2);
+   --% node.f_expr.p_kind
+
+   Y := F1 (1);
+   --% node.f_expr.p_kind
+end Kind;

--- a/testsuite/tests/properties/call_expr_kind/test.out
+++ b/testsuite/tests/properties/call_expr_kind/test.out
@@ -1,0 +1,22 @@
+Eval 'node.f_call.p_kind' on node <CallStmt kind.adb:26:7-26:14>
+Result: 'call'
+
+Eval 'node.f_dest.f_prefix.p_kind' on node <AssignStmt kind.adb:33:4-33:31>
+Result: 'type_conversion'
+
+Eval 'node.f_expr.f_prefix.p_kind' on node <AssignStmt kind.adb:33:4-33:31>
+Result: 'type_conversion'
+
+Eval 'node.f_expr.p_kind' on node <AssignStmt kind.adb:37:4-37:23>
+Result: 'type_conversion'
+
+Eval 'node.f_expr.p_kind' on node <AssignStmt kind.adb:40:4-40:14>
+Result: 'array_index'
+
+Eval 'node.f_expr.p_kind' on node <AssignStmt kind.adb:43:4-43:19>
+Result: 'array_slice'
+
+Eval 'node.f_expr.p_kind' on node <AssignStmt kind.adb:46:4-46:16>
+Result: 'call'
+
+

--- a/testsuite/tests/properties/call_expr_kind/test.yaml
+++ b/testsuite/tests/properties/call_expr_kind/test.yaml
@@ -1,0 +1,2 @@
+driver: inline-playground
+input_sources: [kind.adb]

--- a/user_manual/changes/UC22-030.yaml
+++ b/user_manual/changes/UC22-030.yaml
@@ -1,0 +1,7 @@
+type: new-feature
+title: New property to query the kind of a CallExpr
+description: |
+    Add a new property `CallExpr.kind` to query the kind of a `CallExpr` (call,
+    array slice, array index, or type conversion). It returns a `CallExprKind`
+    enum value.
+date: 2022-01-19


### PR DESCRIPTION
Add a new property `CallExpr.kind` to query the kind of a `CallExpr`
(call, array slice, array index, or type conversion). It returns a
`CallExprKind` enum value.

TN: UC22-030