### PR TITLE
New properties for associating formal parameters to actual or default expressions

### DIFF
--- a/ada/ast.py
+++ b/ada/ast.py
@@ -7740,9 +7740,10 @@ class AnonymousType(TypeExpr):
 class ParamActual(Struct):
     """
     Data structure used by zip_with_params, Name.call_params,
-    GenericInstantiation.inst_params, BaseAggregate.aggregate_params, and
-    SubtypeIndication.subtype_constraints properties. Associates an expression
-    (the actual) to a formal param declaration (the parameter).
+    GenericInstantiation.inst_params, BaseAggregate.aggregate_params,
+    SubtypeIndication.subtype_constraints, and EnumRepClause.params
+    properties. Associates an expression (the actual) to a formal param
+    declaration (the parameter).
     """
     param = UserField(type=T.DefiningName.entity)
     actual = UserField(type=T.Expr.entity)
@@ -8387,6 +8388,26 @@ class EnumRepClause(AspectClause):
     def xref_equation():
         # TODO: resolve names in ``aggregate``
         return Entity.type_name.xref_no_overloading
+
+    @langkit_property(public=True, return_type=ParamActual.array)
+    def params():
+        """
+        Returns an array of pairs, associating enum literals to representation
+        clause actuals.
+        """
+        # Get the enum literals
+        el = Var(Entity.type_name.referenced_decl().cast(T.BaseTypeDecl)
+                 .root_type.cast(T.TypeDecl).type_def.cast(T.EnumTypeDef)
+                 .enum_literals)
+        # Get the representation clause actuals
+        ra = Var(Entity.aggregate.assocs)
+
+        return el.map(
+            lambda i, l: ParamActual.new(
+                param=l.name,
+                actual=ra.actual_for_param_at(l.name, i)
+            )
+        )
 
 
 class AttributeDefClause(AspectClause):

--- a/ada/ast.py
+++ b/ada/ast.py
@@ -11048,6 +11048,16 @@ class RefResult(Struct):
     kind = UserField(type=RefResultKind, default_value=RefResultKind.no_ref)
 
 
+class ParamActual(Struct):
+    """
+    Data structure used by zip_with_params and Name.call_params properties.
+    Associates an expression (the actual) to a formal param declaration (the
+    parameter).
+    """
+    param = UserField(type=T.DefiningName.entity)
+    actual = UserField(type=T.Expr.entity)
+
+
 @abstract
 class Name(Expr):
     """
@@ -11971,6 +11981,73 @@ class Name(Expr):
         Return whether this name denotes a constant value.
         """
         pass
+
+    @langkit_property(public=True, return_type=ParamActual.array)
+    def call_params():
+        """
+        Returns an array of pairs, associating formal parameters to actual or
+        default expressions.
+        """
+        return If(
+            Entity.is_call,
+
+            Let(
+                lambda offset=If(Entity.is_dot_call, 1, 0),
+                # Get the actuals of this call expression if any
+                aparams=Entity.cast(CallExpr)._.params,
+                # Create an array of pairs from the subprogram formals and
+                # default expressions.
+                dparams=Entity.referenced_decl()
+                .subp_spec_or_null._.params.mapcat(
+                    lambda i, p: p.defining_names.map(
+                        lambda n: ParamActual.new(
+                            param=n,
+                            actual=If(
+                                # Handling dot notation (first actual is
+                                # denoted by the prefix of the dot call).
+                                And(Entity.is_dot_call, i == 0),
+
+                                Entity.cast(CallExpr).then(
+                                    lambda c: c.name.cast(DottedName).prefix,
+                                    default_val=Entity.cast(DottedName).prefix
+                                ),
+
+                                p.default_expr
+                            )
+                        )
+                    )
+                ):
+
+                # Create a new array by updating the actuals if the call
+                # expression provides some.
+                aparams.then(
+                    lambda ap: dparams.map(
+                        lambda i, dp: ParamActual.new(
+                            param=dp.param,
+                            # Search if a named param expression exists for
+                            # this formal param in the call assoc list.
+                            actual=If(
+                                # Handling dot notation (do not update first
+                                # actual).
+                                And(Entity.is_dot_call, i == 0),
+
+                                dp.actual,
+
+                                ap.actual_for_param_at(
+                                    dp.param, i-offset, dp.actual
+                                )
+                            )
+                        )
+                    ),
+                    default_val=dparams
+                )
+            ),
+
+            PropertyError(
+                T.ParamActual.array,
+                "this name doesn't reference a call expression"
+            )
+        )
 
 
 class DiscreteSubtypeName(Name):
@@ -12915,19 +12992,40 @@ class MultiDimArrayAssoc(AggregateAssoc):
     pass
 
 
-class ParamActual(Struct):
-    """
-    Data structure used by zip_with_params property. Associates an expression
-    (the actual) to a formal param declaration (the parameter).
-    """
-    param = UserField(type=T.DefiningName.entity)
-    actual = UserField(type=T.Expr.entity)
-
-
 class AssocList(BasicAssoc.list):
     """
     List of associations.
     """
+
+    @langkit_property(return_type=T.Expr.entity, memoized=True)
+    def actual_for_param_at(param=T.DefiningName.entity,
+                            pos=T.Int,
+                            default_expr=(T.Expr.entity, No(T.Expr.entity))):
+        """
+        Return the actual expression for ``param`` if any, ``default_expr``
+        otherwise.
+        """
+        up = Var(Entity.unpacked_params)
+
+        return up.find(
+            # Search expression for parameter `param` if a named one exists
+            lambda p: p.name._.cast(Identifier)
+            .matches(param.name.cast(Identifier).node)
+        ).then(
+            lambda a: a.assoc.expr,
+            # Otherwise, get the parameter using its position if any
+            default_val=If(
+                Or(
+                    up.at(pos).is_null,
+                    Not(up.at(pos).assoc.cast(ParamAssoc).designator.is_null)
+                ),
+                # None was found, either by name or by position, return
+                # default expression.
+                default_expr,
+                # Use expression for param by position
+                up.at(pos).assoc.expr
+            )
+        )
 
     @langkit_property()
     def unpacked_params():

--- a/ada/ast.py
+++ b/ada/ast.py
@@ -9007,9 +9007,10 @@ class ExceptionDecl(BasicDecl):
 
 class ParamActual(Struct):
     """
-    Data structure used by zip_with_params, Name.call_params, and
-    GenericInstantiation.inst_params properties. Associates an expression (the
-    actual) to a formal param declaration (the parameter).
+    Data structure used by zip_with_params, Name.call_params,
+    GenericInstantiation.inst_params, and BaseAggregate.aggregate_params
+    properties. Associates an expression (the actual) to a formal param
+    declaration (the parameter).
     """
     param = UserField(type=T.DefiningName.entity)
     actual = UserField(type=T.Expr.entity)
@@ -11007,6 +11008,14 @@ class BaseAggregate(Expr):
                 ))
             )
         )
+
+    @langkit_property(public=True, return_type=T.ParamActual.array)
+    def aggregate_params():
+        """
+        Returns an array of pairs, associating formal parameters to actual
+        expressions. See ``zip_with_params``.
+        """
+        return Entity.assocs.zip_with_params
 
 
 class Aggregate(BaseAggregate):

--- a/testsuite/tests/properties/aggregate_params/recagg.adb
+++ b/testsuite/tests/properties/aggregate_params/recagg.adb
@@ -1,0 +1,92 @@
+procedure RecAgg is
+   type Month_Name is (January, February, March, April, May, June, July,
+                    August, September, October, November, December);
+
+   type Date is
+      record
+         Day   : Integer range 1 .. 31;
+         Month : Month_Name;
+         Year  : Integer range 0 .. 4000;
+      end record;
+
+   type Device is (Printer, Disk, Drum);
+   type State  is (Open, Closed);
+   subtype Cylinder_Index is Integer range 1 .. 300;
+   subtype Track_Number is Integer range 1 .. 300;
+
+   type Peripheral(Unit : Device := Disk) is
+      record
+         Status : State;
+         case Unit is
+            when Printer =>
+               Line_Count : Integer range 1 .. 10 := 4;
+            when others =>
+               Cylinder   : Cylinder_Index;
+               Track      : Track_Number := 10;
+         end case;
+      end record;
+
+   type Cell;
+   type Link is access Cell;
+
+   type Cell is
+      record
+         Value  : Integer;
+         Succ   : Link;
+         Pred   : Link;
+      end record;
+
+   type Rec is tagged
+      record
+         A : Integer;
+      end record;
+
+   type ExtR is new Rec with
+      record
+         B : Integer;
+      end record;
+
+   D : Date;
+   P : Peripheral;
+   C : Cell;
+   R : Rec;
+   E : ExtR;
+
+begin
+   D := (4, July, 1776);
+   --% node.f_expr.p_aggregate_params
+   D := (Day => 4, Month => July, Year => 1776);
+   --% node.f_expr.p_aggregate_params
+   D := (Month => July, Day => 4, Year => 1776);
+   --% node.f_expr.p_aggregate_params
+
+   P := (Disk, Closed, Track => 5, Cylinder => 12);
+   --% node.f_expr.p_aggregate_params
+   P := (Unit => Disk, Status => Closed, Cylinder => 9, Track => 1);
+   --% node.f_expr.p_aggregate_params
+   P := (Disk, Status => Closed, Cylinder => 12, Track => 2);
+   --% node.f_expr.p_aggregate_params
+   P := (Disk, Closed, 9, 1);
+   --% node.f_expr.p_aggregate_params
+   P := (Disk, Closed, others => 1);
+   --% node.f_expr.p_aggregate_params
+
+   C := (Value => 0, Succ|Pred => new Cell'(0, null, null));
+   --% [x.p_aggregate_params for x in node.findall(lal.Aggregate)]
+   C := (Value => 0, Succ => new Cell'(0, null, null), Pred => new Cell'(0, null, null));
+   --% [x.p_aggregate_params for x in node.findall(lal.Aggregate)]
+   C := (Value => 0, Succ|Pred => <>);
+   --% node.f_expr.p_aggregate_params
+
+   R := (A => 9);
+   --% node.f_expr.p_aggregate_params
+   R := (others => 9);
+   --% node.f_expr.p_aggregate_params
+
+   E := (A|B => 0);
+   --% node.f_expr.p_aggregate_params
+   E := (A => 0, B => 0);
+   --% node.f_expr.p_aggregate_params
+   E := (0, 0);
+   --% node.f_expr.p_aggregate_params
+end RecAgg;

--- a/testsuite/tests/properties/aggregate_params/test.out
+++ b/testsuite/tests/properties/aggregate_params/test.out
@@ -1,0 +1,49 @@
+Eval 'node.f_expr.p_aggregate_params' on node <AssignStmt recagg.adb:56:4-56:25>
+Result: [<ParamActual param=<DefiningName recagg.adb:7:10-7:13> actual=<Int recagg.adb:56:10-56:11>>, <ParamActual param=<DefiningName recagg.adb:8:10-8:15> actual=<Id "July" recagg.adb:56:13-56:17>>, <ParamActual param=<DefiningName recagg.adb:9:10-9:14> actual=<Int recagg.adb:56:19-56:23>>]
+
+Eval 'node.f_expr.p_aggregate_params' on node <AssignStmt recagg.adb:58:4-58:49>
+Result: [<ParamActual param=<DefiningName recagg.adb:7:10-7:13> actual=<Int recagg.adb:58:17-58:18>>, <ParamActual param=<DefiningName recagg.adb:8:10-8:15> actual=<Id "July" recagg.adb:58:29-58:33>>, <ParamActual param=<DefiningName recagg.adb:9:10-9:14> actual=<Int recagg.adb:58:43-58:47>>]
+
+Eval 'node.f_expr.p_aggregate_params' on node <AssignStmt recagg.adb:60:4-60:49>
+Result: [<ParamActual param=<DefiningName recagg.adb:8:10-8:15> actual=<Id "July" recagg.adb:60:19-60:23>>, <ParamActual param=<DefiningName recagg.adb:7:10-7:13> actual=<Int recagg.adb:60:32-60:33>>, <ParamActual param=<DefiningName recagg.adb:9:10-9:14> actual=<Int recagg.adb:60:43-60:47>>]
+
+Eval 'node.f_expr.p_aggregate_params' on node <AssignStmt recagg.adb:63:4-63:52>
+Result: [<ParamActual param=<DefiningName recagg.adb:17:20-17:24> actual=<Id "Disk" recagg.adb:63:10-63:14>>, <ParamActual param=<DefiningName recagg.adb:19:10-19:16> actual=<Id "Closed" recagg.adb:63:16-63:22>>, <ParamActual param=<DefiningName recagg.adb:25:16-25:21> actual=<Int recagg.adb:63:33-63:34>>, <ParamActual param=<DefiningName recagg.adb:24:16-24:24> actual=<Int recagg.adb:63:48-63:50>>]
+
+Eval 'node.f_expr.p_aggregate_params' on node <AssignStmt recagg.adb:65:4-65:69>
+Result: [<ParamActual param=<DefiningName recagg.adb:17:20-17:24> actual=<Id "Disk" recagg.adb:65:18-65:22>>, <ParamActual param=<DefiningName recagg.adb:19:10-19:16> actual=<Id "Closed" recagg.adb:65:34-65:40>>, <ParamActual param=<DefiningName recagg.adb:24:16-24:24> actual=<Int recagg.adb:65:54-65:55>>, <ParamActual param=<DefiningName recagg.adb:25:16-25:21> actual=<Int recagg.adb:65:66-65:67>>]
+
+Eval 'node.f_expr.p_aggregate_params' on node <AssignStmt recagg.adb:67:4-67:62>
+Result: [<ParamActual param=<DefiningName recagg.adb:17:20-17:24> actual=<Id "Disk" recagg.adb:67:10-67:14>>, <ParamActual param=<DefiningName recagg.adb:19:10-19:16> actual=<Id "Closed" recagg.adb:67:26-67:32>>, <ParamActual param=<DefiningName recagg.adb:24:16-24:24> actual=<Int recagg.adb:67:46-67:48>>, <ParamActual param=<DefiningName recagg.adb:25:16-25:21> actual=<Int recagg.adb:67:59-67:60>>]
+
+Eval 'node.f_expr.p_aggregate_params' on node <AssignStmt recagg.adb:69:4-69:30>
+Result: [<ParamActual param=<DefiningName recagg.adb:17:20-17:24> actual=<Id "Disk" recagg.adb:69:10-69:14>>, <ParamActual param=<DefiningName recagg.adb:19:10-19:16> actual=<Id "Closed" recagg.adb:69:16-69:22>>, <ParamActual param=<DefiningName recagg.adb:24:16-24:24> actual=<Int recagg.adb:69:24-69:25>>, <ParamActual param=<DefiningName recagg.adb:25:16-25:21> actual=<Int recagg.adb:69:27-69:28>>]
+
+Eval 'node.f_expr.p_aggregate_params' on node <AssignStmt recagg.adb:71:4-71:37>
+Result: [<ParamActual param=<DefiningName recagg.adb:17:20-17:24> actual=<Id "Disk" recagg.adb:71:10-71:14>>, <ParamActual param=<DefiningName recagg.adb:19:10-19:16> actual=<Id "Closed" recagg.adb:71:16-71:22>>, <ParamActual param=<DefiningName recagg.adb:24:16-24:24> actual=<Int recagg.adb:71:34-71:35>>, <ParamActual param=<DefiningName recagg.adb:25:16-25:21> actual=<Int recagg.adb:71:34-71:35>>]
+
+Eval '[x.p_aggregate_params for x in node.findall(lal.Aggregate)]' on node <AssignStmt recagg.adb:74:4-74:61>
+Result: [[<ParamActual param=<DefiningName recagg.adb:34:10-34:15> actual=<Int recagg.adb:74:19-74:20>>, <ParamActual param=<DefiningName recagg.adb:35:10-35:14> actual=<Allocator recagg.adb:74:35-74:59>>, <ParamActual param=<DefiningName recagg.adb:36:10-36:14> actual=<Allocator recagg.adb:74:35-74:59>>], [<ParamActual param=<DefiningName recagg.adb:34:10-34:15> actual=<Int recagg.adb:74:45-74:46>>, <ParamActual param=<DefiningName recagg.adb:35:10-35:14> actual=<Null recagg.adb:74:48-74:52>>, <ParamActual param=<DefiningName recagg.adb:36:10-36:14> actual=<Null recagg.adb:74:54-74:58>>]]
+
+Eval '[x.p_aggregate_params for x in node.findall(lal.Aggregate)]' on node <AssignStmt recagg.adb:76:4-76:90>
+Result: [[<ParamActual param=<DefiningName recagg.adb:34:10-34:15> actual=<Int recagg.adb:76:19-76:20>>, <ParamActual param=<DefiningName recagg.adb:35:10-35:14> actual=<Allocator recagg.adb:76:30-76:54>>, <ParamActual param=<DefiningName recagg.adb:36:10-36:14> actual=<Allocator recagg.adb:76:64-76:88>>], [<ParamActual param=<DefiningName recagg.adb:34:10-34:15> actual=<Int recagg.adb:76:40-76:41>>, <ParamActual param=<DefiningName recagg.adb:35:10-35:14> actual=<Null recagg.adb:76:43-76:47>>, <ParamActual param=<DefiningName recagg.adb:36:10-36:14> actual=<Null recagg.adb:76:49-76:53>>], [<ParamActual param=<DefiningName recagg.adb:34:10-34:15> actual=<Int recagg.adb:76:74-76:75>>, <ParamActual param=<DefiningName recagg.adb:35:10-35:14> actual=<Null recagg.adb:76:77-76:81>>, <ParamActual param=<DefiningName recagg.adb:36:10-36:14> actual=<Null recagg.adb:76:83-76:87>>]]
+
+Eval 'node.f_expr.p_aggregate_params' on node <AssignStmt recagg.adb:78:4-78:39>
+Result: [<ParamActual param=<DefiningName recagg.adb:34:10-34:15> actual=<Int recagg.adb:78:19-78:20>>, <ParamActual param=<DefiningName recagg.adb:35:10-35:14> actual=<BoxExpr recagg.adb:78:35-78:37>>, <ParamActual param=<DefiningName recagg.adb:36:10-36:14> actual=<BoxExpr recagg.adb:78:35-78:37>>]
+
+Eval 'node.f_expr.p_aggregate_params' on node <AssignStmt recagg.adb:81:4-81:18>
+Result: [<ParamActual param=<DefiningName recagg.adb:41:10-41:11> actual=<Int recagg.adb:81:15-81:16>>]
+
+Eval 'node.f_expr.p_aggregate_params' on node <AssignStmt recagg.adb:83:4-83:23>
+Result: [<ParamActual param=<DefiningName recagg.adb:41:10-41:11> actual=<Int recagg.adb:83:20-83:21>>]
+
+Eval 'node.f_expr.p_aggregate_params' on node <AssignStmt recagg.adb:86:4-86:20>
+Result: [<ParamActual param=<DefiningName recagg.adb:41:10-41:11> actual=<Int recagg.adb:86:17-86:18>>, <ParamActual param=<DefiningName recagg.adb:46:10-46:11> actual=<Int recagg.adb:86:17-86:18>>]
+
+Eval 'node.f_expr.p_aggregate_params' on node <AssignStmt recagg.adb:88:4-88:26>
+Result: [<ParamActual param=<DefiningName recagg.adb:41:10-41:11> actual=<Int recagg.adb:88:15-88:16>>, <ParamActual param=<DefiningName recagg.adb:46:10-46:11> actual=<Int recagg.adb:88:23-88:24>>]
+
+Eval 'node.f_expr.p_aggregate_params' on node <AssignStmt recagg.adb:90:4-90:16>
+Result: [<ParamActual param=<DefiningName recagg.adb:41:10-41:11> actual=<Int recagg.adb:90:10-90:11>>, <ParamActual param=<DefiningName recagg.adb:46:10-46:11> actual=<Int recagg.adb:90:13-90:14>>]
+
+

--- a/testsuite/tests/properties/aggregate_params/test.yaml
+++ b/testsuite/tests/properties/aggregate_params/test.yaml
@@ -1,0 +1,2 @@
+driver: inline-playground
+input_sources: [recagg.adb]

--- a/testsuite/tests/properties/call_params/callp.adb
+++ b/testsuite/tests/properties/call_params/callp.adb
@@ -1,0 +1,124 @@
+procedure Callp is
+   function Function_With_All_Default_Params
+     (p1 : in Integer := 0;
+      p2 : in Integer := 0;
+      p3 : in Integer := 0) return Integer is
+   begin
+      return p1 + p2 + p3;
+   end Function_With_All_Default_Params;
+
+   function Function_With_All_Default_Params2
+     (p1, p2 : in Integer := 0;
+      p3 : in Integer := 0) return Integer is
+   begin
+      return p1 + p2 + p3;
+   end Function_With_All_Default_Params2;
+
+   function Function_With_All_Default_Params3
+     (p1 : in Integer := 0;
+      p2, p3 : in Integer := 0) return Integer is
+   begin
+      return p1 + p2 + p3;
+   end Function_With_All_Default_Params3;
+
+   function Function_With_All_Default_Params4
+     (p1 : in Integer := 0;
+      p2, p3 : in Integer := 0) return Integer
+   is (p1 + p2 + p3);
+
+   function Function_With_Default_Params
+     (p1 : Integer; p2, p3 : in Integer := 0) return Integer
+   is (p1 + p2 + p3);
+
+   X : Integer;
+begin
+   X := Function_With_All_Default_Params;
+   --% node.f_expr.p_call_params
+
+   X := Function_With_All_Default_Params(0,1,2);
+   --% node.f_expr.p_call_params
+
+   X := Function_With_All_Default_Params(2);
+   --% node.f_expr.p_call_params
+
+   X := Function_With_All_Default_Params(p1 => 0, p2 => 1, p3 => 2);
+   --% node.f_expr.p_call_params
+
+   X := Function_With_All_Default_Params(0, p2 => 1, p3 => 2);
+   --% node.f_expr.p_call_params
+
+   X := Function_With_All_Default_Params(0, p3 => 0, p2 => 2);
+   --% node.f_expr.p_call_params
+
+   X := Function_With_All_Default_Params(p2 => 0, p3 => 1);
+   --% node.f_expr.p_call_params
+
+   X := Function_With_All_Default_Params2;
+   --% node.f_expr.p_call_params
+
+   X := Function_With_All_Default_Params2(0,1,2);
+   --% node.f_expr.p_call_params
+
+   X := Function_With_All_Default_Params2(2);
+   --% node.f_expr.p_call_params
+
+   X := Function_With_All_Default_Params2(p1 => 0, p2 => 1, p3 => 2);
+   --% node.f_expr.p_call_params
+
+   X := Function_With_All_Default_Params2(0, p2 => 1, p3 => 2);
+   --% node.f_expr.p_call_params
+
+   X := Function_With_All_Default_Params2(0, p3 => 0, p2 => 2);
+   --% node.f_expr.p_call_params
+
+   X := Function_With_All_Default_Params2(p2 => 0, p3 => 1);
+   --% node.f_expr.p_call_params
+
+   X := Function_With_All_Default_Params3;
+   --% node.f_expr.p_call_params
+
+   X := Function_With_All_Default_Params3(0,1,2);
+   --% node.f_expr.p_call_params
+
+   X := Function_With_All_Default_Params3(2);
+   --% node.f_expr.p_call_params
+
+   X := Function_With_All_Default_Params3(p1 => 0, p2 => 1, p3 => 2);
+   --% node.f_expr.p_call_params
+
+   X := Function_With_All_Default_Params3(0, p2 => 1, p3 => 2);
+   --% node.f_expr.p_call_params
+
+   X := Function_With_All_Default_Params3(0, p3 => 0, p2 => 2);
+   --% node.f_expr.p_call_params
+
+   X := Function_With_All_Default_Params3(p2 => 0, p3 => 1);
+   --% node.f_expr.p_call_params
+
+   X := Function_With_All_Default_Params4;
+   --% node.f_expr.p_call_params
+
+   X := Function_With_All_Default_Params4(0,1,2);
+   --% node.f_expr.p_call_params
+
+   X := Function_With_All_Default_Params4(2);
+   --% node.f_expr.p_call_params
+
+   X := Function_With_All_Default_Params4(p1 => 0, p2 => 1, p3 => 2);
+   --% node.f_expr.p_call_params
+
+   X := Function_With_All_Default_Params4(0, p2 => 1, p3 => 2);
+   --% node.f_expr.p_call_params
+
+   X := Function_With_All_Default_Params4(0, p3 => 0, p2 => 2);
+   --% node.f_expr.p_call_params
+
+   X := Function_With_All_Default_Params4(p2 => 0, p3 => 1);
+   --% node.f_expr.p_call_params
+
+   X := Function_With_Default_Params(0, p3 => 0, p2 => 2);
+   --% node.f_expr.p_call_params
+
+   X := Function_With_Default_Params(0, p3 => 1);
+   --% node.f_expr.p_call_params
+end Callp;

--- a/testsuite/tests/properties/call_params/dot.adb
+++ b/testsuite/tests/properties/call_params/dot.adb
@@ -1,0 +1,56 @@
+procedure Dot is
+   package P1 is
+      procedure P (A : Integer := 0);
+   end P1;
+   package P2 is
+      procedure P (A : Integer := 0);
+
+      type T is tagged null record;
+      procedure PT (S : T; V : Integer := 0) is null;
+      procedure PW (S : T; V : Integer := 0; W : Integer := 1) is null;
+   end P2;
+
+   package body P1 is
+      procedure P (A : Integer := 0) is
+      begin
+         null;
+      end P;
+   end P1;
+   package body P2 is
+      procedure P (A : Integer := 0) is
+      begin
+         null;
+      end P;
+   end P2;
+
+   X : P2.T;
+begin
+   P1.P (A => 0);
+   --% node.f_call.p_call_params
+   P1.P (0);
+   --% node.f_call.p_call_params
+   P1.P;
+   --% node.f_call.p_call_params
+   P2.P (0);
+   --% node.f_call.p_call_params
+   P2.P;
+   --% node.f_call.p_call_params
+   X.PT (0);
+   --% node.f_call.p_call_params
+   X.PT (V => 0);
+   --% node.f_call.p_call_params
+   X.PT;
+   --% node.f_call.p_call_params
+   X.PW (0);
+   --% node.f_call.p_call_params
+   X.PW (V => 0);
+   --% node.f_call.p_call_params
+   X.PW;
+   --% node.f_call.p_call_params
+   X.PW (0, 0);
+   --% node.f_call.p_call_params
+   X.PW (V => 0, W => 0);
+   --% node.f_call.p_call_params
+   X.PW (0, W => 0);
+   --% node.f_call.p_call_params
+end Dot;

--- a/testsuite/tests/properties/call_params/pkg.adb
+++ b/testsuite/tests/properties/call_params/pkg.adb
@@ -1,0 +1,71 @@
+package body Pkg is
+   function F1 (A : Integer := 0; B : Integer := 1) return Integer is
+   begin
+      return A + B;
+   end F1;
+   procedure P1 (A : Integer := 0; B : Integer := 1) is
+   begin
+      null;
+   end P1;
+
+   function F2 (A, B : Integer := 1) return Integer is
+   begin
+      return A + B;
+   end F2;
+   procedure P2 (A, B : Integer := 1) is
+   begin
+      null;
+   end P2;
+
+   function F3 return Integer is
+   begin
+      return 0;
+   end F3;
+   procedure P3 is
+   begin
+      null;
+   end P3;
+
+   procedure Test is
+      X : Integer;
+   begin
+      X := F1;
+      --% node.f_expr.p_call_params
+      X := F1 (0);
+      --% node.f_expr.p_call_params
+      X := F1 (0, 1);
+      --% node.f_expr.p_call_params
+      X := F1 (B => 2);
+      --% node.f_expr.p_call_params
+      P1;
+      --% node.f_call.p_call_params
+      P1 (0);
+      --% node.f_call.p_call_params
+      P1 (0, X);
+      --% node.f_call.p_call_params
+      P1 (B => X);
+      --% node.f_call.p_call_params
+
+      X := F2;
+      --% node.f_expr.p_call_params
+      X := F2 (0);
+      --% node.f_expr.p_call_params
+      X := F2 (0, 1);
+      --% node.f_expr.p_call_params
+      X := F2 (B => 2);
+      --% node.f_expr.p_call_params
+      P2;
+      --% node.f_call.p_call_params
+      P2 (0);
+      --% node.f_call.p_call_params
+      P2 (0, X);
+      --% node.f_call.p_call_params
+      P2 (B => X);
+      --% node.f_call.p_call_params
+
+      X := F3;
+      --% node.f_expr.p_call_params
+      P3;
+      --% node.f_call.p_call_params
+   end Test;
+end Pkg;

--- a/testsuite/tests/properties/call_params/pkg.ads
+++ b/testsuite/tests/properties/call_params/pkg.ads
@@ -1,0 +1,10 @@
+package Pkg is
+   function F1 (A : Integer := 0; B : Integer := 1) return Integer;
+   procedure P1 (A : Integer := 0; B : Integer := 1);
+
+   function F2 (A, B : Integer := 1) return Integer;
+   procedure P2 (A, B : Integer := 1);
+
+   function F3 return Integer;
+   procedure P3;
+end Pkg;

--- a/testsuite/tests/properties/call_params/test.out
+++ b/testsuite/tests/properties/call_params/test.out
@@ -1,0 +1,191 @@
+
+Eval 'node.f_expr.p_call_params' on node <AssignStmt callp.adb:35:4-35:42>
+Result: [<ParamActual param=<DefiningName callp.adb:3:7-3:9> actual=<Int callp.adb:3:26-3:27>>, <ParamActual param=<DefiningName callp.adb:4:7-4:9> actual=<Int callp.adb:4:26-4:27>>, <ParamActual param=<DefiningName callp.adb:5:7-5:9> actual=<Int callp.adb:5:26-5:27>>]
+
+Eval 'node.f_expr.p_call_params' on node <AssignStmt callp.adb:38:4-38:49>
+Result: [<ParamActual param=<DefiningName callp.adb:3:7-3:9> actual=<Int callp.adb:38:42-38:43>>, <ParamActual param=<DefiningName callp.adb:4:7-4:9> actual=<Int callp.adb:38:44-38:45>>, <ParamActual param=<DefiningName callp.adb:5:7-5:9> actual=<Int callp.adb:38:46-38:47>>]
+
+Eval 'node.f_expr.p_call_params' on node <AssignStmt callp.adb:41:4-41:45>
+Result: [<ParamActual param=<DefiningName callp.adb:3:7-3:9> actual=<Int callp.adb:41:42-41:43>>, <ParamActual param=<DefiningName callp.adb:4:7-4:9> actual=<Int callp.adb:4:26-4:27>>, <ParamActual param=<DefiningName callp.adb:5:7-5:9> actual=<Int callp.adb:5:26-5:27>>]
+
+Eval 'node.f_expr.p_call_params' on node <AssignStmt callp.adb:44:4-44:69>
+Result: [<ParamActual param=<DefiningName callp.adb:3:7-3:9> actual=<Int callp.adb:44:48-44:49>>, <ParamActual param=<DefiningName callp.adb:4:7-4:9> actual=<Int callp.adb:44:57-44:58>>, <ParamActual param=<DefiningName callp.adb:5:7-5:9> actual=<Int callp.adb:44:66-44:67>>]
+
+Eval 'node.f_expr.p_call_params' on node <AssignStmt callp.adb:47:4-47:63>
+Result: [<ParamActual param=<DefiningName callp.adb:3:7-3:9> actual=<Int callp.adb:47:42-47:43>>, <ParamActual param=<DefiningName callp.adb:4:7-4:9> actual=<Int callp.adb:47:51-47:52>>, <ParamActual param=<DefiningName callp.adb:5:7-5:9> actual=<Int callp.adb:47:60-47:61>>]
+
+Eval 'node.f_expr.p_call_params' on node <AssignStmt callp.adb:50:4-50:63>
+Result: [<ParamActual param=<DefiningName callp.adb:3:7-3:9> actual=<Int callp.adb:50:42-50:43>>, <ParamActual param=<DefiningName callp.adb:4:7-4:9> actual=<Int callp.adb:50:60-50:61>>, <ParamActual param=<DefiningName callp.adb:5:7-5:9> actual=<Int callp.adb:50:51-50:52>>]
+
+Eval 'node.f_expr.p_call_params' on node <AssignStmt callp.adb:53:4-53:60>
+Result: [<ParamActual param=<DefiningName callp.adb:3:7-3:9> actual=<Int callp.adb:3:26-3:27>>, <ParamActual param=<DefiningName callp.adb:4:7-4:9> actual=<Int callp.adb:53:48-53:49>>, <ParamActual param=<DefiningName callp.adb:5:7-5:9> actual=<Int callp.adb:53:57-53:58>>]
+
+Eval 'node.f_expr.p_call_params' on node <AssignStmt callp.adb:56:4-56:43>
+Result: [<ParamActual param=<DefiningName callp.adb:11:7-11:9> actual=<Int callp.adb:11:30-11:31>>, <ParamActual param=<DefiningName callp.adb:11:11-11:13> actual=<Int callp.adb:11:30-11:31>>, <ParamActual param=<DefiningName callp.adb:12:7-12:9> actual=<Int callp.adb:12:26-12:27>>]
+
+Eval 'node.f_expr.p_call_params' on node <AssignStmt callp.adb:59:4-59:50>
+Result: [<ParamActual param=<DefiningName callp.adb:11:7-11:9> actual=<Int callp.adb:59:43-59:44>>, <ParamActual param=<DefiningName callp.adb:11:11-11:13> actual=<Int callp.adb:59:45-59:46>>, <ParamActual param=<DefiningName callp.adb:12:7-12:9> actual=<Int callp.adb:59:47-59:48>>]
+
+Eval 'node.f_expr.p_call_params' on node <AssignStmt callp.adb:62:4-62:46>
+Result: [<ParamActual param=<DefiningName callp.adb:11:7-11:9> actual=<Int callp.adb:62:43-62:44>>, <ParamActual param=<DefiningName callp.adb:11:11-11:13> actual=<Int callp.adb:11:30-11:31>>, <ParamActual param=<DefiningName callp.adb:12:7-12:9> actual=<Int callp.adb:12:26-12:27>>]
+
+Eval 'node.f_expr.p_call_params' on node <AssignStmt callp.adb:65:4-65:70>
+Result: [<ParamActual param=<DefiningName callp.adb:11:7-11:9> actual=<Int callp.adb:65:49-65:50>>, <ParamActual param=<DefiningName callp.adb:11:11-11:13> actual=<Int callp.adb:65:58-65:59>>, <ParamActual param=<DefiningName callp.adb:12:7-12:9> actual=<Int callp.adb:65:67-65:68>>]
+
+Eval 'node.f_expr.p_call_params' on node <AssignStmt callp.adb:68:4-68:64>
+Result: [<ParamActual param=<DefiningName callp.adb:11:7-11:9> actual=<Int callp.adb:68:43-68:44>>, <ParamActual param=<DefiningName callp.adb:11:11-11:13> actual=<Int callp.adb:68:52-68:53>>, <ParamActual param=<DefiningName callp.adb:12:7-12:9> actual=<Int callp.adb:68:61-68:62>>]
+
+Eval 'node.f_expr.p_call_params' on node <AssignStmt callp.adb:71:4-71:64>
+Result: [<ParamActual param=<DefiningName callp.adb:11:7-11:9> actual=<Int callp.adb:71:43-71:44>>, <ParamActual param=<DefiningName callp.adb:11:11-11:13> actual=<Int callp.adb:71:61-71:62>>, <ParamActual param=<DefiningName callp.adb:12:7-12:9> actual=<Int callp.adb:71:52-71:53>>]
+
+Eval 'node.f_expr.p_call_params' on node <AssignStmt callp.adb:74:4-74:61>
+Result: [<ParamActual param=<DefiningName callp.adb:11:7-11:9> actual=<Int callp.adb:11:30-11:31>>, <ParamActual param=<DefiningName callp.adb:11:11-11:13> actual=<Int callp.adb:74:49-74:50>>, <ParamActual param=<DefiningName callp.adb:12:7-12:9> actual=<Int callp.adb:74:58-74:59>>]
+
+Eval 'node.f_expr.p_call_params' on node <AssignStmt callp.adb:77:4-77:43>
+Result: [<ParamActual param=<DefiningName callp.adb:18:7-18:9> actual=<Int callp.adb:18:26-18:27>>, <ParamActual param=<DefiningName callp.adb:19:7-19:9> actual=<Int callp.adb:19:30-19:31>>, <ParamActual param=<DefiningName callp.adb:19:11-19:13> actual=<Int callp.adb:19:30-19:31>>]
+
+Eval 'node.f_expr.p_call_params' on node <AssignStmt callp.adb:80:4-80:50>
+Result: [<ParamActual param=<DefiningName callp.adb:18:7-18:9> actual=<Int callp.adb:80:43-80:44>>, <ParamActual param=<DefiningName callp.adb:19:7-19:9> actual=<Int callp.adb:80:45-80:46>>, <ParamActual param=<DefiningName callp.adb:19:11-19:13> actual=<Int callp.adb:80:47-80:48>>]
+
+Eval 'node.f_expr.p_call_params' on node <AssignStmt callp.adb:83:4-83:46>
+Result: [<ParamActual param=<DefiningName callp.adb:18:7-18:9> actual=<Int callp.adb:83:43-83:44>>, <ParamActual param=<DefiningName callp.adb:19:7-19:9> actual=<Int callp.adb:19:30-19:31>>, <ParamActual param=<DefiningName callp.adb:19:11-19:13> actual=<Int callp.adb:19:30-19:31>>]
+
+Eval 'node.f_expr.p_call_params' on node <AssignStmt callp.adb:86:4-86:70>
+Result: [<ParamActual param=<DefiningName callp.adb:18:7-18:9> actual=<Int callp.adb:86:49-86:50>>, <ParamActual param=<DefiningName callp.adb:19:7-19:9> actual=<Int callp.adb:86:58-86:59>>, <ParamActual param=<DefiningName callp.adb:19:11-19:13> actual=<Int callp.adb:86:67-86:68>>]
+
+Eval 'node.f_expr.p_call_params' on node <AssignStmt callp.adb:89:4-89:64>
+Result: [<ParamActual param=<DefiningName callp.adb:18:7-18:9> actual=<Int callp.adb:89:43-89:44>>, <ParamActual param=<DefiningName callp.adb:19:7-19:9> actual=<Int callp.adb:89:52-89:53>>, <ParamActual param=<DefiningName callp.adb:19:11-19:13> actual=<Int callp.adb:89:61-89:62>>]
+
+Eval 'node.f_expr.p_call_params' on node <AssignStmt callp.adb:92:4-92:64>
+Result: [<ParamActual param=<DefiningName callp.adb:18:7-18:9> actual=<Int callp.adb:92:43-92:44>>, <ParamActual param=<DefiningName callp.adb:19:7-19:9> actual=<Int callp.adb:92:61-92:62>>, <ParamActual param=<DefiningName callp.adb:19:11-19:13> actual=<Int callp.adb:92:52-92:53>>]
+
+Eval 'node.f_expr.p_call_params' on node <AssignStmt callp.adb:95:4-95:61>
+Result: [<ParamActual param=<DefiningName callp.adb:18:7-18:9> actual=<Int callp.adb:18:26-18:27>>, <ParamActual param=<DefiningName callp.adb:19:7-19:9> actual=<Int callp.adb:95:49-95:50>>, <ParamActual param=<DefiningName callp.adb:19:11-19:13> actual=<Int callp.adb:95:58-95:59>>]
+
+Eval 'node.f_expr.p_call_params' on node <AssignStmt callp.adb:98:4-98:43>
+Result: [<ParamActual param=<DefiningName callp.adb:25:7-25:9> actual=<Int callp.adb:25:26-25:27>>, <ParamActual param=<DefiningName callp.adb:26:7-26:9> actual=<Int callp.adb:26:30-26:31>>, <ParamActual param=<DefiningName callp.adb:26:11-26:13> actual=<Int callp.adb:26:30-26:31>>]
+
+Eval 'node.f_expr.p_call_params' on node <AssignStmt callp.adb:101:4-101:50>
+Result: [<ParamActual param=<DefiningName callp.adb:25:7-25:9> actual=<Int callp.adb:101:43-101:44>>, <ParamActual param=<DefiningName callp.adb:26:7-26:9> actual=<Int callp.adb:101:45-101:46>>, <ParamActual param=<DefiningName callp.adb:26:11-26:13> actual=<Int callp.adb:101:47-101:48>>]
+
+Eval 'node.f_expr.p_call_params' on node <AssignStmt callp.adb:104:4-104:46>
+Result: [<ParamActual param=<DefiningName callp.adb:25:7-25:9> actual=<Int callp.adb:104:43-104:44>>, <ParamActual param=<DefiningName callp.adb:26:7-26:9> actual=<Int callp.adb:26:30-26:31>>, <ParamActual param=<DefiningName callp.adb:26:11-26:13> actual=<Int callp.adb:26:30-26:31>>]
+
+Eval 'node.f_expr.p_call_params' on node <AssignStmt callp.adb:107:4-107:70>
+Result: [<ParamActual param=<DefiningName callp.adb:25:7-25:9> actual=<Int callp.adb:107:49-107:50>>, <ParamActual param=<DefiningName callp.adb:26:7-26:9> actual=<Int callp.adb:107:58-107:59>>, <ParamActual param=<DefiningName callp.adb:26:11-26:13> actual=<Int callp.adb:107:67-107:68>>]
+
+Eval 'node.f_expr.p_call_params' on node <AssignStmt callp.adb:110:4-110:64>
+Result: [<ParamActual param=<DefiningName callp.adb:25:7-25:9> actual=<Int callp.adb:110:43-110:44>>, <ParamActual param=<DefiningName callp.adb:26:7-26:9> actual=<Int callp.adb:110:52-110:53>>, <ParamActual param=<DefiningName callp.adb:26:11-26:13> actual=<Int callp.adb:110:61-110:62>>]
+
+Eval 'node.f_expr.p_call_params' on node <AssignStmt callp.adb:113:4-113:64>
+Result: [<ParamActual param=<DefiningName callp.adb:25:7-25:9> actual=<Int callp.adb:113:43-113:44>>, <ParamActual param=<DefiningName callp.adb:26:7-26:9> actual=<Int callp.adb:113:61-113:62>>, <ParamActual param=<DefiningName callp.adb:26:11-26:13> actual=<Int callp.adb:113:52-113:53>>]
+
+Eval 'node.f_expr.p_call_params' on node <AssignStmt callp.adb:116:4-116:61>
+Result: [<ParamActual param=<DefiningName callp.adb:25:7-25:9> actual=<Int callp.adb:25:26-25:27>>, <ParamActual param=<DefiningName callp.adb:26:7-26:9> actual=<Int callp.adb:116:49-116:50>>, <ParamActual param=<DefiningName callp.adb:26:11-26:13> actual=<Int callp.adb:116:58-116:59>>]
+
+Eval 'node.f_expr.p_call_params' on node <AssignStmt callp.adb:119:4-119:59>
+Result: [<ParamActual param=<DefiningName callp.adb:30:7-30:9> actual=<Int callp.adb:119:38-119:39>>, <ParamActual param=<DefiningName callp.adb:30:21-30:23> actual=<Int callp.adb:119:56-119:57>>, <ParamActual param=<DefiningName callp.adb:30:25-30:27> actual=<Int callp.adb:119:47-119:48>>]
+
+Eval 'node.f_expr.p_call_params' on node <AssignStmt callp.adb:122:4-122:50>
+Result: [<ParamActual param=<DefiningName callp.adb:30:7-30:9> actual=<Int callp.adb:122:38-122:39>>, <ParamActual param=<DefiningName callp.adb:30:21-30:23> actual=<Int callp.adb:30:44-30:45>>, <ParamActual param=<DefiningName callp.adb:30:25-30:27> actual=<Int callp.adb:122:47-122:48>>]
+
+
+Eval 'node.f_call.p_call_params' on node <CallStmt dot.adb:28:4-28:18>
+Result: [<ParamActual param=<DefiningName dot.adb:3:20-3:21> actual=<Int dot.adb:28:15-28:16>>]
+
+Eval 'node.f_call.p_call_params' on node <CallStmt dot.adb:30:4-30:13>
+Result: [<ParamActual param=<DefiningName dot.adb:3:20-3:21> actual=<Int dot.adb:30:10-30:11>>]
+
+Eval 'node.f_call.p_call_params' on node <CallStmt dot.adb:32:4-32:9>
+Result: [<ParamActual param=<DefiningName dot.adb:3:20-3:21> actual=<Int dot.adb:3:35-3:36>>]
+
+Eval 'node.f_call.p_call_params' on node <CallStmt dot.adb:34:4-34:13>
+Result: [<ParamActual param=<DefiningName dot.adb:6:20-6:21> actual=<Int dot.adb:34:10-34:11>>]
+
+Eval 'node.f_call.p_call_params' on node <CallStmt dot.adb:36:4-36:9>
+Result: [<ParamActual param=<DefiningName dot.adb:6:20-6:21> actual=<Int dot.adb:6:35-6:36>>]
+
+Eval 'node.f_call.p_call_params' on node <CallStmt dot.adb:38:4-38:13>
+Result: [<ParamActual param=<DefiningName dot.adb:9:21-9:22> actual=<Id "X" dot.adb:38:4-38:5>>, <ParamActual param=<DefiningName dot.adb:9:28-9:29> actual=<Int dot.adb:38:10-38:11>>]
+
+Eval 'node.f_call.p_call_params' on node <CallStmt dot.adb:40:4-40:18>
+Result: [<ParamActual param=<DefiningName dot.adb:9:21-9:22> actual=<Id "X" dot.adb:40:4-40:5>>, <ParamActual param=<DefiningName dot.adb:9:28-9:29> actual=<Int dot.adb:40:15-40:16>>]
+
+Eval 'node.f_call.p_call_params' on node <CallStmt dot.adb:42:4-42:9>
+Result: [<ParamActual param=<DefiningName dot.adb:9:21-9:22> actual=<Id "X" dot.adb:42:4-42:5>>, <ParamActual param=<DefiningName dot.adb:9:28-9:29> actual=<Int dot.adb:9:43-9:44>>]
+
+Eval 'node.f_call.p_call_params' on node <CallStmt dot.adb:44:4-44:13>
+Result: [<ParamActual param=<DefiningName dot.adb:10:21-10:22> actual=<Id "X" dot.adb:44:4-44:5>>, <ParamActual param=<DefiningName dot.adb:10:28-10:29> actual=<Int dot.adb:44:10-44:11>>, <ParamActual param=<DefiningName dot.adb:10:46-10:47> actual=<Int dot.adb:10:61-10:62>>]
+
+Eval 'node.f_call.p_call_params' on node <CallStmt dot.adb:46:4-46:18>
+Result: [<ParamActual param=<DefiningName dot.adb:10:21-10:22> actual=<Id "X" dot.adb:46:4-46:5>>, <ParamActual param=<DefiningName dot.adb:10:28-10:29> actual=<Int dot.adb:46:15-46:16>>, <ParamActual param=<DefiningName dot.adb:10:46-10:47> actual=<Int dot.adb:10:61-10:62>>]
+
+Eval 'node.f_call.p_call_params' on node <CallStmt dot.adb:48:4-48:9>
+Result: [<ParamActual param=<DefiningName dot.adb:10:21-10:22> actual=<Id "X" dot.adb:48:4-48:5>>, <ParamActual param=<DefiningName dot.adb:10:28-10:29> actual=<Int dot.adb:10:43-10:44>>, <ParamActual param=<DefiningName dot.adb:10:46-10:47> actual=<Int dot.adb:10:61-10:62>>]
+
+Eval 'node.f_call.p_call_params' on node <CallStmt dot.adb:50:4-50:16>
+Result: [<ParamActual param=<DefiningName dot.adb:10:21-10:22> actual=<Id "X" dot.adb:50:4-50:5>>, <ParamActual param=<DefiningName dot.adb:10:28-10:29> actual=<Int dot.adb:50:10-50:11>>, <ParamActual param=<DefiningName dot.adb:10:46-10:47> actual=<Int dot.adb:50:13-50:14>>]
+
+Eval 'node.f_call.p_call_params' on node <CallStmt dot.adb:52:4-52:26>
+Result: [<ParamActual param=<DefiningName dot.adb:10:21-10:22> actual=<Id "X" dot.adb:52:4-52:5>>, <ParamActual param=<DefiningName dot.adb:10:28-10:29> actual=<Int dot.adb:52:15-52:16>>, <ParamActual param=<DefiningName dot.adb:10:46-10:47> actual=<Int dot.adb:52:23-52:24>>]
+
+Eval 'node.f_call.p_call_params' on node <CallStmt dot.adb:54:4-54:21>
+Result: [<ParamActual param=<DefiningName dot.adb:10:21-10:22> actual=<Id "X" dot.adb:54:4-54:5>>, <ParamActual param=<DefiningName dot.adb:10:28-10:29> actual=<Int dot.adb:54:10-54:11>>, <ParamActual param=<DefiningName dot.adb:10:46-10:47> actual=<Int dot.adb:54:18-54:19>>]
+
+
+
+Eval 'node.f_expr.p_call_params' on node <AssignStmt pkg.adb:32:7-32:15>
+Result: [<ParamActual param=<DefiningName pkg.adb:2:17-2:18> actual=<Int pkg.adb:2:32-2:33>>, <ParamActual param=<DefiningName pkg.adb:2:35-2:36> actual=<Int pkg.adb:2:50-2:51>>]
+
+Eval 'node.f_expr.p_call_params' on node <AssignStmt pkg.adb:34:7-34:19>
+Result: [<ParamActual param=<DefiningName pkg.adb:2:17-2:18> actual=<Int pkg.adb:34:16-34:17>>, <ParamActual param=<DefiningName pkg.adb:2:35-2:36> actual=<Int pkg.adb:2:50-2:51>>]
+
+Eval 'node.f_expr.p_call_params' on node <AssignStmt pkg.adb:36:7-36:22>
+Result: [<ParamActual param=<DefiningName pkg.adb:2:17-2:18> actual=<Int pkg.adb:36:16-36:17>>, <ParamActual param=<DefiningName pkg.adb:2:35-2:36> actual=<Int pkg.adb:36:19-36:20>>]
+
+Eval 'node.f_expr.p_call_params' on node <AssignStmt pkg.adb:38:7-38:24>
+Result: [<ParamActual param=<DefiningName pkg.adb:2:17-2:18> actual=<Int pkg.adb:2:32-2:33>>, <ParamActual param=<DefiningName pkg.adb:2:35-2:36> actual=<Int pkg.adb:38:21-38:22>>]
+
+Eval 'node.f_call.p_call_params' on node <CallStmt pkg.adb:40:7-40:10>
+Result: [<ParamActual param=<DefiningName pkg.adb:6:18-6:19> actual=<Int pkg.adb:6:33-6:34>>, <ParamActual param=<DefiningName pkg.adb:6:36-6:37> actual=<Int pkg.adb:6:51-6:52>>]
+
+Eval 'node.f_call.p_call_params' on node <CallStmt pkg.adb:42:7-42:14>
+Result: [<ParamActual param=<DefiningName pkg.adb:6:18-6:19> actual=<Int pkg.adb:42:11-42:12>>, <ParamActual param=<DefiningName pkg.adb:6:36-6:37> actual=<Int pkg.adb:6:51-6:52>>]
+
+Eval 'node.f_call.p_call_params' on node <CallStmt pkg.adb:44:7-44:17>
+Result: [<ParamActual param=<DefiningName pkg.adb:6:18-6:19> actual=<Int pkg.adb:44:11-44:12>>, <ParamActual param=<DefiningName pkg.adb:6:36-6:37> actual=<Id "X" pkg.adb:44:14-44:15>>]
+
+Eval 'node.f_call.p_call_params' on node <CallStmt pkg.adb:46:7-46:19>
+Result: [<ParamActual param=<DefiningName pkg.adb:6:18-6:19> actual=<Int pkg.adb:6:33-6:34>>, <ParamActual param=<DefiningName pkg.adb:6:36-6:37> actual=<Id "X" pkg.adb:46:16-46:17>>]
+
+Eval 'node.f_expr.p_call_params' on node <AssignStmt pkg.adb:49:7-49:15>
+Result: [<ParamActual param=<DefiningName pkg.adb:11:17-11:18> actual=<Int pkg.adb:11:35-11:36>>, <ParamActual param=<DefiningName pkg.adb:11:20-11:21> actual=<Int pkg.adb:11:35-11:36>>]
+
+Eval 'node.f_expr.p_call_params' on node <AssignStmt pkg.adb:51:7-51:19>
+Result: [<ParamActual param=<DefiningName pkg.adb:11:17-11:18> actual=<Int pkg.adb:51:16-51:17>>, <ParamActual param=<DefiningName pkg.adb:11:20-11:21> actual=<Int pkg.adb:11:35-11:36>>]
+
+Eval 'node.f_expr.p_call_params' on node <AssignStmt pkg.adb:53:7-53:22>
+Result: [<ParamActual param=<DefiningName pkg.adb:11:17-11:18> actual=<Int pkg.adb:53:16-53:17>>, <ParamActual param=<DefiningName pkg.adb:11:20-11:21> actual=<Int pkg.adb:53:19-53:20>>]
+
+Eval 'node.f_expr.p_call_params' on node <AssignStmt pkg.adb:55:7-55:24>
+Result: [<ParamActual param=<DefiningName pkg.adb:11:17-11:18> actual=<Int pkg.adb:11:35-11:36>>, <ParamActual param=<DefiningName pkg.adb:11:20-11:21> actual=<Int pkg.adb:55:21-55:22>>]
+
+Eval 'node.f_call.p_call_params' on node <CallStmt pkg.adb:57:7-57:10>
+Result: [<ParamActual param=<DefiningName pkg.adb:15:18-15:19> actual=<Int pkg.adb:15:36-15:37>>, <ParamActual param=<DefiningName pkg.adb:15:21-15:22> actual=<Int pkg.adb:15:36-15:37>>]
+
+Eval 'node.f_call.p_call_params' on node <CallStmt pkg.adb:59:7-59:14>
+Result: [<ParamActual param=<DefiningName pkg.adb:15:18-15:19> actual=<Int pkg.adb:59:11-59:12>>, <ParamActual param=<DefiningName pkg.adb:15:21-15:22> actual=<Int pkg.adb:15:36-15:37>>]
+
+Eval 'node.f_call.p_call_params' on node <CallStmt pkg.adb:61:7-61:17>
+Result: [<ParamActual param=<DefiningName pkg.adb:15:18-15:19> actual=<Int pkg.adb:61:11-61:12>>, <ParamActual param=<DefiningName pkg.adb:15:21-15:22> actual=<Id "X" pkg.adb:61:14-61:15>>]
+
+Eval 'node.f_call.p_call_params' on node <CallStmt pkg.adb:63:7-63:19>
+Result: [<ParamActual param=<DefiningName pkg.adb:15:18-15:19> actual=<Int pkg.adb:15:36-15:37>>, <ParamActual param=<DefiningName pkg.adb:15:21-15:22> actual=<Id "X" pkg.adb:63:16-63:17>>]
+
+Eval 'node.f_expr.p_call_params' on node <AssignStmt pkg.adb:66:7-66:15>
+Result: []
+
+Eval 'node.f_call.p_call_params' on node <CallStmt pkg.adb:68:7-68:10>
+Result: []
+
+

--- a/testsuite/tests/properties/call_params/test.yaml
+++ b/testsuite/tests/properties/call_params/test.yaml
@@ -1,0 +1,2 @@
+driver: inline-playground
+input_sources: [callp.adb, pkg.adb, pkg,ads, dot.adb]

--- a/testsuite/tests/properties/enum_params/proc.adb
+++ b/testsuite/tests/properties/enum_params/proc.adb
@@ -1,0 +1,24 @@
+procedure Proc is
+   type Primary_Color is (Red, Green, Blue);
+
+   type PC1 is new Primary_Color;
+   type PC2 is new Primary_Color;
+   type PC3 is new Primary_Color;
+
+   for PC1 use (-3, 8, 456);
+   --% node.p_params
+   for PC2 use (Red => -3, Green => 8, Blue => 456);
+   --% node.p_params
+   for PC3 use (Green => 8, Red => -3, Blue => 456);
+   --% node.p_params
+
+   type My_Bool3 is new Boolean;
+   for My_Bool3 use (True => 2, False => 0);
+   --% node.p_params
+
+   type My_Bool4 is new My_Bool3;
+   for My_Bool4 use (0, 1);
+   --% node.p_params
+begin
+   null;
+end Proc;

--- a/testsuite/tests/properties/enum_params/test.out
+++ b/testsuite/tests/properties/enum_params/test.out
@@ -1,0 +1,16 @@
+Eval 'node.p_params' on node <EnumRepClause proc.adb:8:4-8:29>
+Result: [<ParamActual param=<DefiningName proc.adb:2:27-2:30> actual=<UnOp proc.adb:8:17-8:19>>, <ParamActual param=<DefiningName proc.adb:2:32-2:37> actual=<Int proc.adb:8:21-8:22>>, <ParamActual param=<DefiningName proc.adb:2:39-2:43> actual=<Int proc.adb:8:24-8:27>>]
+
+Eval 'node.p_params' on node <EnumRepClause proc.adb:10:4-10:53>
+Result: [<ParamActual param=<DefiningName proc.adb:2:27-2:30> actual=<UnOp proc.adb:10:24-10:26>>, <ParamActual param=<DefiningName proc.adb:2:32-2:37> actual=<Int proc.adb:10:37-10:38>>, <ParamActual param=<DefiningName proc.adb:2:39-2:43> actual=<Int proc.adb:10:48-10:51>>]
+
+Eval 'node.p_params' on node <EnumRepClause proc.adb:12:4-12:53>
+Result: [<ParamActual param=<DefiningName proc.adb:2:27-2:30> actual=<UnOp proc.adb:12:36-12:38>>, <ParamActual param=<DefiningName proc.adb:2:32-2:37> actual=<Int proc.adb:12:26-12:27>>, <ParamActual param=<DefiningName proc.adb:2:39-2:43> actual=<Int proc.adb:12:48-12:51>>]
+
+Eval 'node.p_params' on node <EnumRepClause proc.adb:16:4-16:45>
+Result: [<ParamActual param=<DefiningName __standard:3:20-3:25> actual=<Int proc.adb:16:42-16:43>>, <ParamActual param=<DefiningName __standard:3:27-3:31> actual=<Int proc.adb:16:30-16:31>>]
+
+Eval 'node.p_params' on node <EnumRepClause proc.adb:20:4-20:28>
+Result: [<ParamActual param=<DefiningName __standard:3:20-3:25> actual=<Int proc.adb:20:22-20:23>>, <ParamActual param=<DefiningName __standard:3:27-3:31> actual=<Int proc.adb:20:25-20:26>>]
+
+

--- a/testsuite/tests/properties/enum_params/test.yaml
+++ b/testsuite/tests/properties/enum_params/test.yaml
@@ -1,0 +1,2 @@
+driver: inline-playground
+input_sources: [proc.adb]

--- a/testsuite/tests/properties/inst_params/geni.adb
+++ b/testsuite/tests/properties/inst_params/geni.adb
@@ -1,0 +1,102 @@
+procedure Geni is
+   generic
+      type T is private;
+   procedure P1 (A : T);
+
+   generic
+      type T1 is private;
+      type T2 is private;
+   procedure P2 (A : T1; B : T1; C : T2);
+
+   generic
+      type T is private;
+      X, Y : T;
+   procedure P4 (A : T);
+
+   generic
+      type T is private;
+      X, Y : T;
+      M : Integer := 0;
+      N : Integer := 0;
+   procedure P5 (A : T);
+
+   generic
+      type T is private;
+      X, Y: T;
+      M, N : Integer := 0;
+   procedure P6 (A : T);
+
+   procedure P1 (A : T) is null;
+   procedure P2 (A : T1; B : T1; C : T2) is null;
+   procedure P4 (A : T) is null;
+   procedure P5 (A : T) is null;
+   procedure P6 (A : T) is null;
+
+   procedure I1P1 is new P1 (Integer);
+   --% node.p_inst_params
+   procedure I2P1 is new P1 (T => Integer);
+   --% node.p_inst_params
+
+   procedure I1P2 is new P2 (Integer, Float);
+   --% node.p_inst_params
+   procedure I2P2 is new P2 (T2 => Integer, T1 => Float);
+   --% node.p_inst_params
+
+   procedure I1P4 is new P4 (Integer, 0, 1);
+   --% node.p_inst_params
+   procedure I2P4 is new P4 (X => 0, Y => 0, T => Integer);
+   --% node.p_inst_params
+   procedure I3P4 is new P4 (Integer, Y => 0, X => 0);
+   --% node.p_inst_params
+
+   procedure I1P5 is new P5 (Integer, 0, 1, 2, 3);
+   --% node.p_inst_params
+   procedure I2P5 is new P5 (Integer, 0, 1, N => 2, M => 3);
+   --% node.p_inst_params
+   procedure I3P5 is new P5 (Integer, Y => 0, M => 1, N => 2, X => 3);
+   --% node.p_inst_params
+   procedure I4P5 is new P5 (Y => 0, M => 1, N => 2, X => 3, T => Integer);
+   --% node.p_inst_params
+   procedure I5P5 is new P5 (Integer, Y => 0, X => 3);
+   --% node.p_inst_params
+   procedure I6P5 is new P5 (Integer, Y => 0, M => 0, X => 3);
+   --% node.p_inst_params
+
+   procedure I1P6 is new P6 (Integer, 0, 1, 2, 3);
+   --% node.p_inst_params
+   procedure I2P6 is new P6 (Integer, 0, 1, N => 2, M => 3);
+   --% node.p_inst_params
+   procedure I3P6 is new P6 (Integer, Y => 0, M => 1, N => 2, X => 3);
+   --% node.p_inst_params
+   procedure I4P6 is new P6 (Y => 0, M => 1, N => 2, X => 3, T => Integer);
+   --% node.p_inst_params
+   procedure I5P6 is new P6 (Integer, Y => 0, X => 3);
+   --% node.p_inst_params
+   procedure I6P6 is new P6 (Integer, Y => 0, M => 0, X => 3);
+   --% node.p_inst_params
+
+   generic
+      type T is private;
+      X : Integer := 0;
+      Y, Z : Integer := 1;
+      M : Integer;
+   package PA is
+      procedure P1 (A : T);
+   private
+      procedure P1 (A : T) is null;
+   end PA;
+
+   package I1PA is new PA (Integer, M => 0);
+   --% node.p_inst_params
+   package I2PA is new PA (T => Integer, M => 8);
+   --% node.p_inst_params
+   package I3PA is new PA (Integer, 0, 0, 0, 0);
+   --% node.p_inst_params
+   package I4PA is new PA (Integer, Z => 0, X => 0, Y => 0, M => 0);
+   --% node.p_inst_params
+   package I5PA is new PA (X => 0, Y => 0, Z => 0, T => Integer, M => 0);
+   --% node.p_inst_params
+
+begin
+   null;
+end Geni;

--- a/testsuite/tests/properties/inst_params/test.out
+++ b/testsuite/tests/properties/inst_params/test.out
@@ -1,0 +1,73 @@
+Eval 'node.p_inst_params' on node <GenericSubpInstantiation ["I1P1"] geni.adb:35:4-35:39>
+Result: [<ParamActual param=<DefiningName geni.adb:3:12-3:13> actual=<Id "Integer" geni.adb:35:30-35:37>>]
+
+Eval 'node.p_inst_params' on node <GenericSubpInstantiation ["I2P1"] geni.adb:37:4-37:44>
+Result: [<ParamActual param=<DefiningName geni.adb:3:12-3:13> actual=<Id "Integer" geni.adb:37:35-37:42>>]
+
+Eval 'node.p_inst_params' on node <GenericSubpInstantiation ["I1P2"] geni.adb:40:4-40:46>
+Result: [<ParamActual param=<DefiningName geni.adb:7:12-7:14> actual=<Id "Integer" geni.adb:40:30-40:37>>, <ParamActual param=<DefiningName geni.adb:8:12-8:14> actual=<Id "Float" geni.adb:40:39-40:44>>]
+
+Eval 'node.p_inst_params' on node <GenericSubpInstantiation ["I2P2"] geni.adb:42:4-42:58>
+Result: [<ParamActual param=<DefiningName geni.adb:7:12-7:14> actual=<Id "Float" geni.adb:42:51-42:56>>, <ParamActual param=<DefiningName geni.adb:8:12-8:14> actual=<Id "Integer" geni.adb:42:36-42:43>>]
+
+Eval 'node.p_inst_params' on node <GenericSubpInstantiation ["I1P4"] geni.adb:45:4-45:45>
+Result: [<ParamActual param=<DefiningName geni.adb:12:12-12:13> actual=<Id "Integer" geni.adb:45:30-45:37>>, <ParamActual param=<DefiningName geni.adb:13:7-13:8> actual=<Int geni.adb:45:39-45:40>>, <ParamActual param=<DefiningName geni.adb:13:10-13:11> actual=<Int geni.adb:45:42-45:43>>]
+
+Eval 'node.p_inst_params' on node <GenericSubpInstantiation ["I2P4"] geni.adb:47:4-47:60>
+Result: [<ParamActual param=<DefiningName geni.adb:12:12-12:13> actual=<Id "Integer" geni.adb:47:51-47:58>>, <ParamActual param=<DefiningName geni.adb:13:7-13:8> actual=<Int geni.adb:47:35-47:36>>, <ParamActual param=<DefiningName geni.adb:13:10-13:11> actual=<Int geni.adb:47:43-47:44>>]
+
+Eval 'node.p_inst_params' on node <GenericSubpInstantiation ["I3P4"] geni.adb:49:4-49:55>
+Result: [<ParamActual param=<DefiningName geni.adb:12:12-12:13> actual=<Id "Integer" geni.adb:49:30-49:37>>, <ParamActual param=<DefiningName geni.adb:13:7-13:8> actual=<Int geni.adb:49:52-49:53>>, <ParamActual param=<DefiningName geni.adb:13:10-13:11> actual=<Int geni.adb:49:44-49:45>>]
+
+Eval 'node.p_inst_params' on node <GenericSubpInstantiation ["I1P5"] geni.adb:52:4-52:51>
+Result: [<ParamActual param=<DefiningName geni.adb:17:12-17:13> actual=<Id "Integer" geni.adb:52:30-52:37>>, <ParamActual param=<DefiningName geni.adb:18:7-18:8> actual=<Int geni.adb:52:39-52:40>>, <ParamActual param=<DefiningName geni.adb:18:10-18:11> actual=<Int geni.adb:52:42-52:43>>, <ParamActual param=<DefiningName geni.adb:19:7-19:8> actual=<Int geni.adb:52:45-52:46>>, <ParamActual param=<DefiningName geni.adb:20:7-20:8> actual=<Int geni.adb:52:48-52:49>>]
+
+Eval 'node.p_inst_params' on node <GenericSubpInstantiation ["I2P5"] geni.adb:54:4-54:61>
+Result: [<ParamActual param=<DefiningName geni.adb:17:12-17:13> actual=<Id "Integer" geni.adb:54:30-54:37>>, <ParamActual param=<DefiningName geni.adb:18:7-18:8> actual=<Int geni.adb:54:39-54:40>>, <ParamActual param=<DefiningName geni.adb:18:10-18:11> actual=<Int geni.adb:54:42-54:43>>, <ParamActual param=<DefiningName geni.adb:19:7-19:8> actual=<Int geni.adb:54:58-54:59>>, <ParamActual param=<DefiningName geni.adb:20:7-20:8> actual=<Int geni.adb:54:50-54:51>>]
+
+Eval 'node.p_inst_params' on node <GenericSubpInstantiation ["I3P5"] geni.adb:56:4-56:71>
+Result: [<ParamActual param=<DefiningName geni.adb:17:12-17:13> actual=<Id "Integer" geni.adb:56:30-56:37>>, <ParamActual param=<DefiningName geni.adb:18:7-18:8> actual=<Int geni.adb:56:68-56:69>>, <ParamActual param=<DefiningName geni.adb:18:10-18:11> actual=<Int geni.adb:56:44-56:45>>, <ParamActual param=<DefiningName geni.adb:19:7-19:8> actual=<Int geni.adb:56:52-56:53>>, <ParamActual param=<DefiningName geni.adb:20:7-20:8> actual=<Int geni.adb:56:60-56:61>>]
+
+Eval 'node.p_inst_params' on node <GenericSubpInstantiation ["I4P5"] geni.adb:58:4-58:76>
+Result: [<ParamActual param=<DefiningName geni.adb:17:12-17:13> actual=<Id "Integer" geni.adb:58:67-58:74>>, <ParamActual param=<DefiningName geni.adb:18:7-18:8> actual=<Int geni.adb:58:59-58:60>>, <ParamActual param=<DefiningName geni.adb:18:10-18:11> actual=<Int geni.adb:58:35-58:36>>, <ParamActual param=<DefiningName geni.adb:19:7-19:8> actual=<Int geni.adb:58:43-58:44>>, <ParamActual param=<DefiningName geni.adb:20:7-20:8> actual=<Int geni.adb:58:51-58:52>>]
+
+Eval 'node.p_inst_params' on node <GenericSubpInstantiation ["I5P5"] geni.adb:60:4-60:55>
+Result: [<ParamActual param=<DefiningName geni.adb:17:12-17:13> actual=<Id "Integer" geni.adb:60:30-60:37>>, <ParamActual param=<DefiningName geni.adb:18:7-18:8> actual=<Int geni.adb:60:52-60:53>>, <ParamActual param=<DefiningName geni.adb:18:10-18:11> actual=<Int geni.adb:60:44-60:45>>, <ParamActual param=<DefiningName geni.adb:19:7-19:8> actual=<Int geni.adb:19:22-19:23>>, <ParamActual param=<DefiningName geni.adb:20:7-20:8> actual=<Int geni.adb:20:22-20:23>>]
+
+Eval 'node.p_inst_params' on node <GenericSubpInstantiation ["I6P5"] geni.adb:62:4-62:63>
+Result: [<ParamActual param=<DefiningName geni.adb:17:12-17:13> actual=<Id "Integer" geni.adb:62:30-62:37>>, <ParamActual param=<DefiningName geni.adb:18:7-18:8> actual=<Int geni.adb:62:60-62:61>>, <ParamActual param=<DefiningName geni.adb:18:10-18:11> actual=<Int geni.adb:62:44-62:45>>, <ParamActual param=<DefiningName geni.adb:19:7-19:8> actual=<Int geni.adb:62:52-62:53>>, <ParamActual param=<DefiningName geni.adb:20:7-20:8> actual=<Int geni.adb:20:22-20:23>>]
+
+Eval 'node.p_inst_params' on node <GenericSubpInstantiation ["I1P6"] geni.adb:65:4-65:51>
+Result: [<ParamActual param=<DefiningName geni.adb:24:12-24:13> actual=<Id "Integer" geni.adb:65:30-65:37>>, <ParamActual param=<DefiningName geni.adb:25:7-25:8> actual=<Int geni.adb:65:39-65:40>>, <ParamActual param=<DefiningName geni.adb:25:10-25:11> actual=<Int geni.adb:65:42-65:43>>, <ParamActual param=<DefiningName geni.adb:26:7-26:8> actual=<Int geni.adb:65:45-65:46>>, <ParamActual param=<DefiningName geni.adb:26:10-26:11> actual=<Int geni.adb:65:48-65:49>>]
+
+Eval 'node.p_inst_params' on node <GenericSubpInstantiation ["I2P6"] geni.adb:67:4-67:61>
+Result: [<ParamActual param=<DefiningName geni.adb:24:12-24:13> actual=<Id "Integer" geni.adb:67:30-67:37>>, <ParamActual param=<DefiningName geni.adb:25:7-25:8> actual=<Int geni.adb:67:39-67:40>>, <ParamActual param=<DefiningName geni.adb:25:10-25:11> actual=<Int geni.adb:67:42-67:43>>, <ParamActual param=<DefiningName geni.adb:26:7-26:8> actual=<Int geni.adb:67:58-67:59>>, <ParamActual param=<DefiningName geni.adb:26:10-26:11> actual=<Int geni.adb:67:50-67:51>>]
+
+Eval 'node.p_inst_params' on node <GenericSubpInstantiation ["I3P6"] geni.adb:69:4-69:71>
+Result: [<ParamActual param=<DefiningName geni.adb:24:12-24:13> actual=<Id "Integer" geni.adb:69:30-69:37>>, <ParamActual param=<DefiningName geni.adb:25:7-25:8> actual=<Int geni.adb:69:68-69:69>>, <ParamActual param=<DefiningName geni.adb:25:10-25:11> actual=<Int geni.adb:69:44-69:45>>, <ParamActual param=<DefiningName geni.adb:26:7-26:8> actual=<Int geni.adb:69:52-69:53>>, <ParamActual param=<DefiningName geni.adb:26:10-26:11> actual=<Int geni.adb:69:60-69:61>>]
+
+Eval 'node.p_inst_params' on node <GenericSubpInstantiation ["I4P6"] geni.adb:71:4-71:76>
+Result: [<ParamActual param=<DefiningName geni.adb:24:12-24:13> actual=<Id "Integer" geni.adb:71:67-71:74>>, <ParamActual param=<DefiningName geni.adb:25:7-25:8> actual=<Int geni.adb:71:59-71:60>>, <ParamActual param=<DefiningName geni.adb:25:10-25:11> actual=<Int geni.adb:71:35-71:36>>, <ParamActual param=<DefiningName geni.adb:26:7-26:8> actual=<Int geni.adb:71:43-71:44>>, <ParamActual param=<DefiningName geni.adb:26:10-26:11> actual=<Int geni.adb:71:51-71:52>>]
+
+Eval 'node.p_inst_params' on node <GenericSubpInstantiation ["I5P6"] geni.adb:73:4-73:55>
+Result: [<ParamActual param=<DefiningName geni.adb:24:12-24:13> actual=<Id "Integer" geni.adb:73:30-73:37>>, <ParamActual param=<DefiningName geni.adb:25:7-25:8> actual=<Int geni.adb:73:52-73:53>>, <ParamActual param=<DefiningName geni.adb:25:10-25:11> actual=<Int geni.adb:73:44-73:45>>, <ParamActual param=<DefiningName geni.adb:26:7-26:8> actual=<Int geni.adb:26:25-26:26>>, <ParamActual param=<DefiningName geni.adb:26:10-26:11> actual=<Int geni.adb:26:25-26:26>>]
+
+Eval 'node.p_inst_params' on node <GenericSubpInstantiation ["I6P6"] geni.adb:75:4-75:63>
+Result: [<ParamActual param=<DefiningName geni.adb:24:12-24:13> actual=<Id "Integer" geni.adb:75:30-75:37>>, <ParamActual param=<DefiningName geni.adb:25:7-25:8> actual=<Int geni.adb:75:60-75:61>>, <ParamActual param=<DefiningName geni.adb:25:10-25:11> actual=<Int geni.adb:75:44-75:45>>, <ParamActual param=<DefiningName geni.adb:26:7-26:8> actual=<Int geni.adb:75:52-75:53>>, <ParamActual param=<DefiningName geni.adb:26:10-26:11> actual=<Int geni.adb:26:25-26:26>>]
+
+Eval 'node.p_inst_params' on node <GenericPackageInstantiation ["I1PA"] geni.adb:89:4-89:45>
+Result: [<ParamActual param=<DefiningName geni.adb:79:12-79:13> actual=<Id "Integer" geni.adb:89:28-89:35>>, <ParamActual param=<DefiningName geni.adb:80:7-80:8> actual=<Int geni.adb:80:22-80:23>>, <ParamActual param=<DefiningName geni.adb:81:7-81:8> actual=<Int geni.adb:81:25-81:26>>, <ParamActual param=<DefiningName geni.adb:81:10-81:11> actual=<Int geni.adb:81:25-81:26>>, <ParamActual param=<DefiningName geni.adb:82:7-82:8> actual=<Int geni.adb:89:42-89:43>>]
+
+Eval 'node.p_inst_params' on node <GenericPackageInstantiation ["I2PA"] geni.adb:91:4-91:50>
+Result: [<ParamActual param=<DefiningName geni.adb:79:12-79:13> actual=<Id "Integer" geni.adb:91:33-91:40>>, <ParamActual param=<DefiningName geni.adb:80:7-80:8> actual=<Int geni.adb:80:22-80:23>>, <ParamActual param=<DefiningName geni.adb:81:7-81:8> actual=<Int geni.adb:81:25-81:26>>, <ParamActual param=<DefiningName geni.adb:81:10-81:11> actual=<Int geni.adb:81:25-81:26>>, <ParamActual param=<DefiningName geni.adb:82:7-82:8> actual=<Int geni.adb:91:47-91:48>>]
+
+Eval 'node.p_inst_params' on node <GenericPackageInstantiation ["I3PA"] geni.adb:93:4-93:49>
+Result: [<ParamActual param=<DefiningName geni.adb:79:12-79:13> actual=<Id "Integer" geni.adb:93:28-93:35>>, <ParamActual param=<DefiningName geni.adb:80:7-80:8> actual=<Int geni.adb:93:37-93:38>>, <ParamActual param=<DefiningName geni.adb:81:7-81:8> actual=<Int geni.adb:93:40-93:41>>, <ParamActual param=<DefiningName geni.adb:81:10-81:11> actual=<Int geni.adb:93:43-93:44>>, <ParamActual param=<DefiningName geni.adb:82:7-82:8> actual=<Int geni.adb:93:46-93:47>>]
+
+Eval 'node.p_inst_params' on node <GenericPackageInstantiation ["I4PA"] geni.adb:95:4-95:69>
+Result: [<ParamActual param=<DefiningName geni.adb:79:12-79:13> actual=<Id "Integer" geni.adb:95:28-95:35>>, <ParamActual param=<DefiningName geni.adb:80:7-80:8> actual=<Int geni.adb:95:50-95:51>>, <ParamActual param=<DefiningName geni.adb:81:7-81:8> actual=<Int geni.adb:95:58-95:59>>, <ParamActual param=<DefiningName geni.adb:81:10-81:11> actual=<Int geni.adb:95:42-95:43>>, <ParamActual param=<DefiningName geni.adb:82:7-82:8> actual=<Int geni.adb:95:66-95:67>>]
+
+Eval 'node.p_inst_params' on node <GenericPackageInstantiation ["I5PA"] geni.adb:97:4-97:74>
+Result: [<ParamActual param=<DefiningName geni.adb:79:12-79:13> actual=<Id "Integer" geni.adb:97:57-97:64>>, <ParamActual param=<DefiningName geni.adb:80:7-80:8> actual=<Int geni.adb:97:33-97:34>>, <ParamActual param=<DefiningName geni.adb:81:7-81:8> actual=<Int geni.adb:97:41-97:42>>, <ParamActual param=<DefiningName geni.adb:81:10-81:11> actual=<Int geni.adb:97:49-97:50>>, <ParamActual param=<DefiningName geni.adb:82:7-82:8> actual=<Int geni.adb:97:71-97:72>>]
+
+

--- a/testsuite/tests/properties/inst_params/test.yaml
+++ b/testsuite/tests/properties/inst_params/test.yaml
@@ -1,0 +1,2 @@
+driver: inline-playground
+input_sources: [geni.adb]

--- a/testsuite/tests/properties/subtype_constraints/discr.adb
+++ b/testsuite/tests/properties/subtype_constraints/discr.adb
@@ -1,0 +1,32 @@
+procedure Discr is
+   type Device is (Printer, Disk, Drum);
+   type State  is (Open, Closed);
+   subtype Cylinder_Index is Integer range 1 .. 300;
+   subtype Track_Number is Integer range 1 .. 300;
+
+   type Peripheral(Unit : Device := Disk; Trk1, Trk2 : Track_Number := 5) is
+      record
+         Status : State;
+         case Unit is
+            when Printer =>
+               Line_Count : Integer range 1 .. 10 := 4;
+            when others =>
+               Cylinder   : Cylinder_Index;
+               Track1     : Track_Number := Trk1;
+               --% node.f_component_def.f_type_expr.p_subtype_constraints
+               Track2     : Track_Number := Trk2;
+         end case;
+      end record;
+
+   P1 : Peripheral;
+   --% node.f_type_expr.p_subtype_constraints
+   P2 : Peripheral (Unit => Printer, Trk1 => 2, Trk2 => 1);
+   --% node.f_type_expr.p_subtype_constraints
+   P3 : Peripheral (Printer, 3, 4);
+   --% node.f_type_expr.p_subtype_constraints
+   P4 : Peripheral (Trk1|Trk2 => 2, Unit => Printer);
+   --% node.f_type_expr.p_subtype_constraints
+
+begin
+   null;
+end Discr;

--- a/testsuite/tests/properties/subtype_constraints/test.out
+++ b/testsuite/tests/properties/subtype_constraints/test.out
@@ -1,0 +1,16 @@
+Eval 'node.f_component_def.f_type_expr.p_subtype_constraints' on node <ComponentDecl ["Track1"] discr.adb:15:16-15:50>
+Result: []
+
+Eval 'node.f_type_expr.p_subtype_constraints' on node <ObjectDecl ["P1"] discr.adb:21:4-21:20>
+Result: [<ParamActual param=<DefiningName discr.adb:7:20-7:24> actual=<Id "Disk" discr.adb:7:37-7:41>>, <ParamActual param=<DefiningName discr.adb:7:43-7:47> actual=<Int discr.adb:7:72-7:73>>, <ParamActual param=<DefiningName discr.adb:7:49-7:53> actual=<Int discr.adb:7:72-7:73>>]
+
+Eval 'node.f_type_expr.p_subtype_constraints' on node <ObjectDecl ["P2"] discr.adb:23:4-23:60>
+Result: [<ParamActual param=<DefiningName discr.adb:7:20-7:24> actual=<Id "Printer" discr.adb:23:29-23:36>>, <ParamActual param=<DefiningName discr.adb:7:43-7:47> actual=<Int discr.adb:23:46-23:47>>, <ParamActual param=<DefiningName discr.adb:7:49-7:53> actual=<Int discr.adb:23:57-23:58>>]
+
+Eval 'node.f_type_expr.p_subtype_constraints' on node <ObjectDecl ["P3"] discr.adb:25:4-25:36>
+Result: [<ParamActual param=<DefiningName discr.adb:7:20-7:24> actual=<Id "Printer" discr.adb:25:21-25:28>>, <ParamActual param=<DefiningName discr.adb:7:43-7:47> actual=<Int discr.adb:25:30-25:31>>, <ParamActual param=<DefiningName discr.adb:7:49-7:53> actual=<Int discr.adb:25:33-25:34>>]
+
+Eval 'node.f_type_expr.p_subtype_constraints' on node <ObjectDecl ["P4"] discr.adb:27:4-27:54>
+Result: [<ParamActual param=<DefiningName discr.adb:7:20-7:24> actual=<Id "Printer" discr.adb:27:45-27:52>>, <ParamActual param=<DefiningName discr.adb:7:43-7:47> actual=<Int discr.adb:27:34-27:35>>, <ParamActual param=<DefiningName discr.adb:7:49-7:53> actual=<Int discr.adb:27:34-27:35>>]
+
+

--- a/testsuite/tests/properties/subtype_constraints/test.yaml
+++ b/testsuite/tests/properties/subtype_constraints/test.yaml
@@ -1,0 +1,2 @@
+driver: inline-playground
+input_sources: [discr.adb]

--- a/user_manual/changes/T622-004.yaml
+++ b/user_manual/changes/T622-004.yaml
@@ -1,0 +1,10 @@
+type: new-feature
+title: Add the new property ``Name.call_params``
+description: |
+    This property, when called on a ``Name`` denoting a call expression, returns
+    an array of parameter-expression pair (the ``ParamActual`` struct is used to
+    hold this pair of ``DefiningName`` and ``Expr`` nodes). It returns all the
+    parameters of the function, even those that are not provided explicitly by
+    the call. In that case, the expression associated with that parameter is the
+    default expression defined by the function/procedure specification.
+date: 2022-01-21

--- a/user_manual/changes/T622-004.yaml
+++ b/user_manual/changes/T622-004.yaml
@@ -1,10 +1,16 @@
 type: new-feature
-title: Add the new property ``Name.call_params``
+title: |
+    New properties for associating formal parameters to actual or default
+    expressions.
+short_title: Formal params to actuals or defaults
 description: |
-    This property, when called on a ``Name`` denoting a call expression, returns
-    an array of parameter-expression pair (the ``ParamActual`` struct is used to
-    hold this pair of ``DefiningName`` and ``Expr`` nodes). It returns all the
-    parameters of the function, even those that are not provided explicitly by
-    the call. In that case, the expression associated with that parameter is the
-    default expression defined by the function/procedure specification.
+    Add the new properties ``Name.call_params`` and
+    ``GenericInstantiation.inst_params``. Those properties, when called on a
+    ``Name`` denoting a call expression, or a generic instantiation, return an
+    array of parameter-expression pair (the ``ParamActual`` struct is used to
+    hold this pair of ``DefiningName`` and ``Expr`` nodes). They return all the
+    parameters of the function (or the generic instantiation), even those that
+    are not provided explicitly by the call (or the generic instantiation). In
+    that case, the expression associated with that parameter is the default
+    expression defined by the function or generic specification.
 date: 2022-01-21

--- a/user_manual/changes/T622-004.yaml
+++ b/user_manual/changes/T622-004.yaml
@@ -6,14 +6,15 @@ short_title: Formal params to actuals or defaults
 description: |
     Add the new properties ``Name.call_params``,
     ``GenericInstantiation.inst_params``, ``BaseAggregate.aggregate_params``,
-    and ``SubtypeIndication.subtype_constraints``. Those properties, when called
-    on a ``Name`` denoting a call expression, a generic instantiation, an
-    aggregate, or a subtype discriminants list, return an array of
-    parameter-expression pair (the ``ParamActual`` struct is used to hold this
-    pair of ``DefiningName`` and ``Expr`` nodes). They return all the parameters
-    of the function (or generic instantiation/aggregate/discriminants list),
-    even those that are not provided explicitly by the call (the generic
-    instantiation, or the discriminants list). In that case, the expression
-    associated with that parameter is the default expression defined by the
-    function, generic or discriminants specification.
+    ``SubtypeIndication.subtype_constraints``, and ``EnumRepClause.params``.
+    Those properties, when called on a ``Name`` denoting a call expression, a
+    generic instantiation, an aggregate, a subtype discriminants list, or an
+    enum representation clause, return an array of parameter-expression pair
+    (the ``ParamActual`` struct is used to hold this pair of ``DefiningName``
+    and ``Expr`` nodes). They return all the parameters of the function (or
+    generic instantiation/aggregate/discriminants list), even those that are not
+    provided explicitly by the call (the generic instantiation, or the
+    discriminants list). In that case, the expression associated with that
+    parameter is the default expression defined by the function, generic or
+    discriminants specification.
 date: 2022-01-21

--- a/user_manual/changes/T622-004.yaml
+++ b/user_manual/changes/T622-004.yaml
@@ -5,14 +5,15 @@ title: |
 short_title: Formal params to actuals or defaults
 description: |
     Add the new properties ``Name.call_params``,
-    ``GenericInstantiation.inst_params``, and
-    ``BaseAggregate.aggregate_params``. Those properties, when called on a
-    ``Name`` denoting a call expression, a generic instantiation, or an
-    aggregate, return an array of parameter-expression pair (the ``ParamActual``
-    struct is used to hold this pair of ``DefiningName`` and ``Expr`` nodes).
-    They return all the parameters of the function (or generic
-    instantiation/aggregate), even those that are not provided explicitly by the
-    call (or the generic instantiation). In that case, the expression associated
-    with that parameter is the default expression defined by the function or
-    generic specification.
+    ``GenericInstantiation.inst_params``, ``BaseAggregate.aggregate_params``,
+    and ``SubtypeIndication.subtype_constraints``. Those properties, when called
+    on a ``Name`` denoting a call expression, a generic instantiation, an
+    aggregate, or a subtype discriminants list, return an array of
+    parameter-expression pair (the ``ParamActual`` struct is used to hold this
+    pair of ``DefiningName`` and ``Expr`` nodes). They return all the parameters
+    of the function (or generic instantiation/aggregate/discriminants list),
+    even those that are not provided explicitly by the call (the generic
+    instantiation, or the discriminants list). In that case, the expression
+    associated with that parameter is the default expression defined by the
+    function, generic or discriminants specification.
 date: 2022-01-21

--- a/user_manual/changes/T622-004.yaml
+++ b/user_manual/changes/T622-004.yaml
@@ -4,13 +4,15 @@ title: |
     expressions.
 short_title: Formal params to actuals or defaults
 description: |
-    Add the new properties ``Name.call_params`` and
-    ``GenericInstantiation.inst_params``. Those properties, when called on a
-    ``Name`` denoting a call expression, or a generic instantiation, return an
-    array of parameter-expression pair (the ``ParamActual`` struct is used to
-    hold this pair of ``DefiningName`` and ``Expr`` nodes). They return all the
-    parameters of the function (or the generic instantiation), even those that
-    are not provided explicitly by the call (or the generic instantiation). In
-    that case, the expression associated with that parameter is the default
-    expression defined by the function or generic specification.
+    Add the new properties ``Name.call_params``,
+    ``GenericInstantiation.inst_params``, and
+    ``BaseAggregate.aggregate_params``. Those properties, when called on a
+    ``Name`` denoting a call expression, a generic instantiation, or an
+    aggregate, return an array of parameter-expression pair (the ``ParamActual``
+    struct is used to hold this pair of ``DefiningName`` and ``Expr`` nodes).
+    They return all the parameters of the function (or generic
+    instantiation/aggregate), even those that are not provided explicitly by the
+    call (or the generic instantiation). In that case, the expression associated
+    with that parameter is the default expression defined by the function or
+    generic specification.
 date: 2022-01-21


### PR DESCRIPTION
Add the new properties ``Name.call_params``, ``GenericInstantiation.inst_params``, ``BaseAggregate.aggregate_params``, ``SubtypeIndication.subtype_constraints``, and ``EnumRepClause.params``. 

TN: T622-004
TN: S617-020
TN: V202-011