### PR TITLE
Fix ``SingleTaskTypeDecl.next_part_for_decl``

### DIFF
--- a/ada/ast.py
+++ b/ada/ast.py
@@ -5461,6 +5461,11 @@ class BaseTypeDecl(BasicDecl):
     def next_part():
         """
         Returns the next part for this type decl.
+
+        .. note:: Since this property returns a ``BaseTypeDecl``, it cannot be
+            used to retrieve the next part of ``TaskTypeDecl`` and
+            ``ProtectedTypeDecl`` nodes as their next part is actually a
+            ``Body``. Use ``BasicDecl.next_part_for_decl`` for those instead.
         """
 
         return Entity.match(
@@ -5576,6 +5581,10 @@ class BaseTypeDecl(BasicDecl):
     @langkit_property()
     def next_part_for_decl():
         return Entity.match(
+            # SingleTaskTypeDecl next part is its parent SingleTaskDecl next
+            # part.
+            lambda sttd=T.SingleTaskTypeDecl:
+            sttd.parent_basic_decl.basic_decl_next_part_for_decl,
             lambda ttd=T.TaskTypeDecl: ttd.basic_decl_next_part_for_decl,
             lambda _: Entity.next_part.cast(T.BasicDecl.entity)
         )

--- a/testsuite/tests/properties/next_part_for_decl/bug-sb08-025.adb
+++ b/testsuite/tests/properties/next_part_for_decl/bug-sb08-025.adb
@@ -1,0 +1,35 @@
+procedure Main is
+
+   task type Worker is
+      entry Start;
+   end Worker;
+   --% node.p_next_part_for_decl()
+
+   task body Worker is
+   begin
+      accept Start;
+      accept Start;
+   end Worker;
+
+   Workers : array (1 .. 4) of Worker;
+
+   task Count_Down
+   --% node.parent.parent.p_next_part_for_decl()
+   is
+      entry Start;
+   end Count_Down;
+   --% node.p_next_part_for_decl()
+
+   task body Count_Down is
+   begin
+      accept Start;
+      for J of Workers loop
+         J.Start;
+         delay 1.0;
+      end loop;
+      accept Start;
+   end Count_Down;
+
+begin
+   Count_Down.Start;
+end Main;

--- a/testsuite/tests/properties/next_part_for_decl/test.out
+++ b/testsuite/tests/properties/next_part_for_decl/test.out
@@ -1,0 +1,10 @@
+Eval 'node.p_next_part_for_decl()' on node <TaskTypeDecl ["Worker"] bug-sb08-025.adb:3:4-5:15>
+Result: <TaskBody ["Worker"] bug-sb08-025.adb:8:4-12:15>
+
+Eval 'node.parent.parent.p_next_part_for_decl()' on node <Id "Count_Down" bug-sb08-025.adb:16:9-16:19>
+Result: <TaskBody ["Count_Down"] bug-sb08-025.adb:23:4-31:19>
+
+Eval 'node.p_next_part_for_decl()' on node <SingleTaskDecl ["Count_Down"] bug-sb08-025.adb:16:4-20:19>
+Result: <TaskBody ["Count_Down"] bug-sb08-025.adb:23:4-31:19>
+
+

--- a/testsuite/tests/properties/next_part_for_decl/test.yaml
+++ b/testsuite/tests/properties/next_part_for_decl/test.yaml
@@ -1,0 +1,2 @@
+driver: inline-playground
+input_sources: [bug-sb08-025.adb]

--- a/user_manual/changes/sb08-025.yaml
+++ b/user_manual/changes/sb08-025.yaml
@@ -1,0 +1,7 @@
+type: bugfix
+title: Fix ``SingleTaskTypeDecl.next_part_for_decl``
+description: |
+  This change fixes a bug where ``next_part_for_decl``, when called on a
+  ``SingleTaskTypeDecl`` returns None instead of the next part of its
+  ``SingleTaskDecl`` parent.
+date: 2022-02-01


### PR DESCRIPTION
This change fixes a bug where ``next_part_for_decl``, when called on a
``SingleTaskTypeDecl`` returns None instead of the next part of its
``SingleTaskDecl`` parent.

TN: SB08-025