### PR TITLE
V203-005 re-enable relocatable libs

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -37,9 +37,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: AdaCore/gprbuild
-          # `gprbuild` directory raises a conflict in alr:
-          # https://github.com/alire-project/alire/issues/864
-          path: gprbuild_
+          path: gprbuild
       - name: Get gnatcoll core
         uses: actions/checkout@v2
         with:

--- a/utils/gh-build-binaries.sh
+++ b/utils/gh-build-binaries.sh
@@ -15,47 +15,58 @@ export DYLD_LIBRARY_PATH=/usr/local/lib
 export PATH=`ls -d $PWD/cached_gnat/*/bin |tr '\n' ':'`$PATH
 echo PATH=$PATH
 
-LIBRARY_TYPES="static"
-
 pip install -r langkit/REQUIREMENTS.dev
 pip install jsonschema
 pip install langkit/
-
-export MACOSX_DEPLOYMENT_TARGET=10.11
-
-alr --non-interactive get xmlada
-cd xmlada*
-./configure --prefix=$prefix ${DEBUG:+--enable-build=Debug}
-make all install
-cd ..
-
-make -C gprbuild_ prefix=$prefix BUILD=${DEBUG:-production} GPRBUILD_OPTIONS="-cargs:C -Dst_mtim=st_mtimespec -gargs" libgpr.build.{shared,static} libgpr.install.{shared,static}
-BUILD=`echo $DEBUG| tr [a-z] [A-Z]`  # Convert to uppercase
-
-# On MacOS ld links unneeded process-wrappers.o into ALS executable and
-# includes ___darwin_check_fd_set_overflow symbols, that prevents execution
-# on older Mac OS X. See #875 in als repo.
-rm -rfv gnatcoll-core/src/os/unix/process-wrappers.c
-
-make -C gnatcoll-core prefix=$prefix BUILD=${BUILD:-PROD} LIBRARY_TYPES="${LIBRARY_TYPES/,/ }" build install
-python gnatcoll-bindings/iconv/setup.py build ${DEBUG:+--debug} -j0 --prefix=$prefix --library-types=$LIBRARY_TYPES
-python gnatcoll-bindings/iconv/setup.py install
-python gnatcoll-bindings/gmp/setup.py build ${DEBUG:+--debug} -j0 --prefix=$prefix --library-types=$LIBRARY_TYPES
-python gnatcoll-bindings/gmp/setup.py install
-
-# Disable SAL for langkit library
-sed -i -e '/for Library_Interface use/,/;/d' langkit/support/langkit_support.gpr
 eval `langkit/manage.py setenv`
-langkit/manage.py build-langkit-support --library-types $LIBRARY_TYPES
-langkit/manage.py install-langkit-support $prefix --library-types $LIBRARY_TYPES
+alr --non-interactive get xmlada
 
-BUILD=${DEBUG:+dev}  # Convert debug to dev
+build_archive()
+{
+  LIBRARY_TYPE=$1
+  rm -rf $prefix
+  cd xmlada*
+  ./configure --prefix=$prefix ${DEBUG:+--enable-build=Debug}
+  make $LIBRARY_TYPE install-$LIBRARY_TYPE
+  cd ..
 
-# Build libadalang static library
-./manage.py generate
-# Disable SAL for libadalang library
-sed -i -e '/for Interfaces use/,/;/d' ./build/libadalang.gpr
-./manage.py build --library-types=static --build-mode ${BUILD:-prod}
-./manage.py install --library-types=static --build-mode ${BUILD:-prod} $prefix
-gprinstall --uninstall --prefix=$prefix mains.gpr
-tar czf libadalang-$RUNNER_OS-`basename $GITHUB_REF`${DEBUG:+-dbg}-static.tar.gz -C $prefix .
+  make -C gprbuild prefix=$prefix BUILD=${DEBUG:-production} \
+    GPRBUILD_OPTIONS="-cargs:C -Dst_mtim=st_mtimespec -gargs" \
+    libgpr.build.$2 libgpr.install.$2
+
+  BUILD=`echo $DEBUG| tr [a-z] [A-Z]`  # Convert to uppercase
+
+  make -C gnatcoll-core prefix=$prefix BUILD=${BUILD:-PROD} LIBRARY_TYPES=$LIBRARY_TYPE build install
+  python gnatcoll-bindings/iconv/setup.py build ${DEBUG:+--debug} -j0 --prefix=$prefix --library-types=$LIBRARY_TYPE
+  python gnatcoll-bindings/iconv/setup.py install
+  python gnatcoll-bindings/gmp/setup.py build ${DEBUG:+--debug} -j0 --prefix=$prefix --library-types=$LIBRARY_TYPE
+  python gnatcoll-bindings/gmp/setup.py install
+
+  langkit/manage.py build-langkit-support --library-types=$LIBRARY_TYPE
+  langkit/manage.py install-langkit-support $prefix --library-types=$LIBRARY_TYPE
+
+  BUILD=${DEBUG:+dev}  # Convert debug to dev
+
+  # Build libadalang static library
+  ./manage.py generate
+
+  if [ $LIBRARY_TYPE = "static"]; then
+    # Disable SAL for static libadalang library
+    sed -i -e '/for .*Interface.* use/,/;/d' ./build/libadalang.gpr
+  fi
+
+  ./manage.py build --library-types=$LIBRARY_TYPE --build-mode ${BUILD:-prod}
+  ./manage.py install --library-types=$LIBRARY_TYPE --build-mode ${BUILD:-prod} $prefix
+  gprinstall --uninstall --prefix=$prefix mains.gpr
+  tar czf libadalang-$RUNNER_OS-`basename $GITHUB_REF`${DEBUG:+-dbg}-$LIBRARY_TYPE.tar.gz -C $prefix .
+}
+
+# Disable SAL for static langkit library
+sed -i -e '/for .*Interface.* use/,/;/d' langkit/support/langkit_support.gpr
+
+build_archive "static" "static"
+
+if [ $RUNNER_OS = Linux ]; then
+   git -C langkit checkout support/langkit_support.gpr
+   build_archive "relocatable" "shared"
+fi


### PR DESCRIPTION
This commit also reverts 3fe78ead4951920435d958c1de0588473822caaa
"U922-009 Don't use SAL for static libraries in GH CI"

Is also reverts 7b31725fc70f01b49bcad788d625072c071fd548
"Drop unneeded C sources to fix Mac OS compat issue"
because that change doesn't help.

It also deletes a workaround for Alire bug (see `gprbuild_`).